### PR TITLE
Publish nightly versions using Travis CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,8 @@ yarn-error.log*
 /packages/*/test/**/*.js
 /packages/*/test/**/*.js.map
 /packages/*/test/**/*.d.ts
+/scripts/*.js
+/scripts/*.js.map
 
 !/packages/*/baselines/**
 !/packages/*/test/fixtures/**

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,4 @@ script:
   - yarn check-dependencies
   - yarn test
 after_success:
-  - node scripts/nightly $TRAVIS_COMMIT_RANGE
+  - node scripts/nightly "$TRAVIS_COMMIT_RANGE"

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,4 @@ script:
   - yarn check-dependencies
   - yarn test
 after_success:
-  - echo deployment goes here
+  - node scripts/nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,4 @@ script:
   - yarn check-dependencies
   - yarn test
 after_success:
-  - node scripts/nightly
+  - node scripts/nightly $TRAVIS_COMMIT_RANGE

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: node_js
+node_js:
+  - node
+cache: yarn
+script:
+  - yarn compile
+  - yarn lint
+  - 'false'
+  - yarn check-dependencies
+  - yarn test

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ cache: yarn
 script:
   - yarn compile
   - yarn lint
-  - 'false'
   - yarn check-dependencies
   - yarn test
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,5 @@ script:
   - 'false'
   - yarn check-dependencies
   - yarn test
+after_success:
+  - echo deployment goes here

--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "version": "0.1.0",
   "private": true,
   "scripts": {
     "compile:wotan": "tsc -p packages/wotan/tsconfig.build.json",
@@ -6,6 +7,7 @@
     "compile:bifrost": "tsc -p packages/bifrost",
     "compile:heimdall": "tsc -p packages/heimdall",
     "compile:disir": "tsc -p packages/disir",
+    "compile:scripts": "tsc -p scripts",
     "compile": "run-p compile:*",
     "lint:wotan": "cd packages/wotan && yarn lint",
     "lint:ve": "cd packages/ve && yarn lint",

--- a/packages/bifrost/src/index.ts
+++ b/packages/bifrost/src/index.ts
@@ -7,7 +7,6 @@ export function wrapTslintRule(Rule: TSLint.RuleConstructor, name: string): Rule
         public static requiresTypeInformation =
             !!(Rule.metadata && Rule.metadata.requiresTypeInfo) ||
             Rule.prototype instanceof TSLint.Rules.TypedRule;
-
         public static deprecated = Rule.metadata && typeof Rule.metadata.deprecationMessage === 'string'
             ? Rule.metadata.deprecationMessage || true // empty deprecation message is coerced to true
             : false;

--- a/packages/wotan/src/services/line-switches.ts
+++ b/packages/wotan/src/services/line-switches.ts
@@ -8,6 +8,7 @@ export type DisableMap = Map<string, ts.TextRange[]>;
 @injectable()
 export class LineSwitchService {
     constructor(private parser: LineSwitchParser) {}
+
     public getDisabledRanges(sourceFile: ts.SourceFile, enabledRules: ReadonlyArray<string>, getWrappedAst?: () => WrappedAst) {
         let wrappedAst: WrappedAst | undefined;
         const raw = this.parser.parse(sourceFile, enabledRules, {

--- a/scripts/nightly.ts
+++ b/scripts/nightly.ts
@@ -1,0 +1,59 @@
+import * as fs from 'fs';
+import * as cp from 'child_process';
+
+interface Dependencies {
+    [name: string]: string;
+}
+
+interface PackageData {
+    name: string;
+    version: string;
+    private?: boolean;
+    dependencies?: Dependencies;
+    devDependencies?: Dependencies;
+    peerDependencies?: Dependencies;
+}
+
+const currentDate = new Date();
+const version = // tslint:disable-next-line
+    `${require('../package.json').version}-dev.${currentDate.getFullYear() * 10000 + (currentDate.getMonth() + 1) * 100 + currentDate.getDate()}`;
+
+const packages = new Map(
+    fs.readdirSync('packages').map((name): [string, PackageData] => {
+        return [name, require(`../packages/${name}/package.json`)];
+    }),
+);
+const publicPackages = new Map(Array.from(packages).filter((v) => !v[1].private));
+
+const changed = new Set<string>();
+function markChanged(name: string) {
+    if (changed.has(name))
+        return;
+    changed.add(name);
+    const manifest = packages.get(name)!;
+    manifest.version = version;
+    for (const [k, v] of publicPackages) {
+        if (v.dependencies && v.dependencies[manifest.name]) {
+            v.dependencies[manifest.name] = version;
+            markChanged(k);
+        }
+        if (v.peerDependencies && v.peerDependencies[manifest.name]) {
+            v.peerDependencies[manifest.name] = version;
+            markChanged(k);
+        }
+    }
+}
+
+console.log(process.env.TRAVIS_COMMIT_RANGE);
+const diff = cp.execSync(
+    `git diff --name-only -- packages/${Array.from(publicPackages.keys()).join(' packages/')}`,
+    {encoding: 'utf8'},
+).trim();
+if (diff !== '')
+    for (const file of diff.split(/\r?\n/))
+        markChanged(file.split(/[/\\]/)[1]);
+
+for (const name of changed) {
+    fs.writeFileSync(`packages/${name}/package.json`, JSON.stringify(publicPackages.get(name), undefined, 2) + '\n');
+    console.log(`npm publish packages/${name} --tag next`);
+}

--- a/scripts/nightly.ts
+++ b/scripts/nightly.ts
@@ -44,8 +44,13 @@ function markChanged(name: string) {
     }
 }
 
+const commits = process.env.TRAVIS_COMMIT_RANGE!.split('...');
+const lastReleaseTag = cp.execSync('git describe --tags --match=v*.*.* --abbrev=0', {encoding: 'utf8'}).trim();
+// if there was a release since the last nightly, only get the diff since the release
+const diffStart = cp.execSync(`git rev-list ${lastReleaseTag}...${commits[0]}`, {encoding: 'utf8'}).split(/\r?\n/)[0];
+
 const diff = cp.execSync(
-    `git diff ${process.env.TRAVIS_COMMIT_RANGE} --name-only -- packages/${Array.from(publicPackages.keys()).join(' packages/')}`,
+    `git diff ${diffStart} --name-only -- packages/${Array.from(publicPackages.keys()).join(' packages/')}`,
     {encoding: 'utf8'},
 ).trim();
 if (diff !== '')

--- a/scripts/nightly.ts
+++ b/scripts/nightly.ts
@@ -1,8 +1,8 @@
 import * as fs from 'fs';
 import * as cp from 'child_process';
 
-if (process.argv.length !== 3) {
-    console.log('Usage: node scripts/nightly <rev>');
+if (process.argv.length < 3) {
+    console.log('Usage: node scripts/nightly <rev> [<options>...]');
     process.exit(1);
 }
 
@@ -69,5 +69,5 @@ for (const file of diff.split('\0'))
 
 for (const name of changed) {
     fs.writeFileSync(`packages/${name}/package.json`, JSON.stringify(publicPackages.get(name), undefined, 2) + '\n');
-    console.log(cp.exec(`npm publish packages/${name} --tag next`, {encoding: 'utf8'}));
+    console.log(cp.execSync(`npm publish packages/${name} --tag next ${process.argv.slice(3).join(' ')}`, {encoding: 'utf8'}));
 }

--- a/scripts/nightly.ts
+++ b/scripts/nightly.ts
@@ -46,8 +46,10 @@ function markChanged(name: string) {
 
 const commits = process.env.TRAVIS_COMMIT_RANGE!.split('...');
 const lastReleaseTag = cp.execSync('git describe --tags --match=v*.*.* --abbrev=0', {encoding: 'utf8'}).trim();
+console.log('last release tag', lastReleaseTag);
 // if there was a release since the last nightly, only get the diff since the release
 const diffStart = cp.execSync(`git rev-list ${lastReleaseTag}...${commits[0]}`, {encoding: 'utf8'}).split(/\r?\n/)[0];
+console.log('newest release', diffStart);
 
 const diff = cp.execSync(
     `git diff ${diffStart} --name-only -- packages/${Array.from(publicPackages.keys()).join(' packages/')}`,

--- a/scripts/nightly.ts
+++ b/scripts/nightly.ts
@@ -61,5 +61,5 @@ if (diff !== '')
 
 for (const name of changed) {
     fs.writeFileSync(`packages/${name}/package.json`, JSON.stringify(publicPackages.get(name), undefined, 2) + '\n');
-    cp.exec(`npm publish packages/${name} --tag next`);
+    console.log(cp.exec(`npm publish packages/${name} --tag next`));
 }

--- a/scripts/nightly.ts
+++ b/scripts/nightly.ts
@@ -44,9 +44,8 @@ function markChanged(name: string) {
     }
 }
 
-console.log(process.env.TRAVIS_COMMIT_RANGE);
 const diff = cp.execSync(
-    `git diff --name-only -- packages/${Array.from(publicPackages.keys()).join(' packages/')}`,
+    `git diff ${process.env.TRAVIS_COMMIT_RANGE} --name-only -- packages/${Array.from(publicPackages.keys()).join(' packages/')}`,
     {encoding: 'utf8'},
 ).trim();
 if (diff !== '')

--- a/scripts/nightly.ts
+++ b/scripts/nightly.ts
@@ -61,5 +61,5 @@ if (diff !== '')
 
 for (const name of changed) {
     fs.writeFileSync(`packages/${name}/package.json`, JSON.stringify(publicPackages.get(name), undefined, 2) + '\n');
-    console.log(`npm publish packages/${name} --tag next`);
+    cp.exec(`npm publish packages/${name} --tag next`);
 }

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../tsconfig-base.json",
+  "include": [
+    "."
+  ],
+  "exclude": [
+  ]
+}


### PR DESCRIPTION
#### Checklist

- [ ] Fixes: #
- [ ] Added or updated tests / baselines
- [ ] Documentation update

#### Overview of change 
The script get's the diff since the last relase (stable or nightly). It updates and publishes all packages that were changed or that depend (also transitively) on a changed package excluding private packages.