### PR TITLE
Add release script for minor and major releases

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "codecov": "^3.0.0",
     "npm-run-all": "^4.1.2",
     "nyc": "^11.4.1",
+    "semver": "^5.5.0",
     "tslint": "^5.9.1",
     "tslint-consistent-codestyle": "^1.11.1",
     "typescript": "^2.7.1"

--- a/packages/bifrost/src/index.ts
+++ b/packages/bifrost/src/index.ts
@@ -7,6 +7,7 @@ export function wrapTslintRule(Rule: TSLint.RuleConstructor, name: string): Rule
         public static requiresTypeInformation =
             !!(Rule.metadata && Rule.metadata.requiresTypeInfo) ||
             Rule.prototype instanceof TSLint.Rules.TypedRule;
+
         public static deprecated = Rule.metadata && typeof Rule.metadata.deprecationMessage === 'string'
             ? Rule.metadata.deprecationMessage || true // empty deprecation message is coerced to true
             : false;

--- a/scripts/nightly.ts
+++ b/scripts/nightly.ts
@@ -1,57 +1,39 @@
-import * as fs from 'fs';
 import * as cp from 'child_process';
+import { getLastRelaseTag, getPackages, getChangedPackageNames, writeManifest, execAndLog } from './util';
 
 if (process.argv.length < 3) {
     console.log('Usage: node scripts/nightly <rev> [<options>...]');
     process.exit(1);
 }
 
-interface Dependencies {
-    [name: string]: string;
-}
-
-interface PackageData {
-    name: string;
-    version: string;
-    private?: boolean;
-    dependencies?: Dependencies;
-    devDependencies?: Dependencies;
-    peerDependencies?: Dependencies;
-}
-
 const currentDate = new Date();
 const version = // tslint:disable-next-line
     `${require('../package.json').version}-dev.${currentDate.getFullYear() * 10000 + (currentDate.getMonth() + 1) * 100 + currentDate.getDate()}`;
 
-const packages = new Map(
-    fs.readdirSync('packages').map((name): [string, PackageData] => {
-        return [name, require(`../packages/${name}/package.json`)];
-    }),
-);
-const publicPackages = new Map(Array.from(packages).filter((v) => !v[1].private));
+const {packages, publicPackages} = getPackages();
 
-const changed = new Set<string>();
-function markChanged(name: string) {
-    if (changed.has(name))
+const needsRelease = new Set<string>();
+function markForRelease(name: string) {
+    if (needsRelease.has(name))
         return;
-    changed.add(name);
+    needsRelease.add(name);
     const manifest = packages.get(name)!;
     manifest.version = version;
     for (const [k, v] of publicPackages) {
         if (v.dependencies && v.dependencies[manifest.name]) {
             v.dependencies[manifest.name] = version;
-            markChanged(k);
+            markForRelease(k);
         }
         if (v.peerDependencies && v.peerDependencies[manifest.name]) {
             v.peerDependencies[manifest.name] = version;
-            markChanged(k);
+            markForRelease(k);
         }
     }
 }
 
 const lastNightly = process.argv[2].split('..')[0]; // revision of the last nightly
 console.log('last nightly release', lastNightly);
-const lastReleaseTag = cp.execSync('git describe --tags --match=v*.*.* --abbrev=0', {encoding: 'utf8'}).trim();
+const lastReleaseTag = getLastRelaseTag();
 console.log('last stable release tag', lastReleaseTag);
 // if there was a release since the last nightly, only get the diff since that release
 const diffStart = lastNightly
@@ -59,15 +41,10 @@ const diffStart = lastNightly
     : lastReleaseTag;
 console.log('releasing changes since', diffStart);
 
-const diff = cp.execSync(
-    `git diff ${diffStart} --name-only -z --no-color -- packages/${Array.from(publicPackages.keys()).join(' packages/')}`,
-    {encoding: 'utf8'},
-).trim();
-for (const file of diff.split('\0'))
-    if (file)
-        markChanged(file.split(/[/\\]/)[1]);
+for (const name of getChangedPackageNames(diffStart, publicPackages.keys()))
+    markForRelease(name);
 
-for (const name of changed) {
-    fs.writeFileSync(`packages/${name}/package.json`, JSON.stringify(publicPackages.get(name), undefined, 2) + '\n');
-    console.log(cp.execSync(`npm publish packages/${name} --tag next ${process.argv.slice(3).join(' ')}`, {encoding: 'utf8'}));
+for (const name of needsRelease) {
+    writeManifest(`packages/${name}/package.json`, publicPackages.get(name)!);
+    execAndLog(`npm publish packages/${name} --tag next ${process.argv.slice(3).join(' ')}`);
 }

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -1,0 +1,41 @@
+import { getPackages, getChangedPackageNames, getLastRelaseTag, PackageData, writeManifest, execAndLog } from './util';
+import * as semver from 'semver';
+
+const rootManifest = require('../package.json'); // tslint:disable-line
+const releaseVersion = rootManifest.version;
+const version = new semver.SemVer(releaseVersion);
+const isMajor = version.minor === 0 && version.patch === 0 && version.prerelease.length === 0 && version.build.length === 0;
+
+const {packages, publicPackages} = getPackages();
+
+const needsRelease = isMajor ? new Set(packages.keys()) : getChangedPackageNames(getLastRelaseTag(), publicPackages.keys());
+
+function updateManifest(path: string, manifest: PackageData, toVersion: string) {
+    manifest.version = toVersion;
+    for (const localName of needsRelease) {
+        const {name} = packages.get(localName)!;
+        if (manifest.dependencies && manifest.dependencies[name])
+            manifest.dependencies[name] = `^${releaseVersion}`;
+        if (manifest.peerDependencies && manifest.peerDependencies[name])
+            manifest.peerDependencies[name] = `^${releaseVersion}`;
+        if (isMajor && manifest.devDependencies && manifest.devDependencies[name])
+            manifest.devDependencies[name] = `^${releaseVersion}`;
+    }
+    writeManifest(path, manifest);
+}
+
+updateManifest('package.json', rootManifest, semver.inc(version, 'minor')!); // set root version to next minor version
+for (const [name, manifest] of packages)
+    if (needsRelease.has(name))
+        updateManifest(`packages/${name}/package.json`, manifest, releaseVersion);
+
+writeManifest('package.json', rootManifest);
+for (const [name, manifest] of packages) {
+    if (!manifest.private && needsRelease.has(name)) {
+        execAndLog(`npm publish packages/${name} --tag latest ${process.argv.slice(2).join(' ')}`);
+        execAndLog(`npm dist-tag ${manifest.name}@${manifest.version} next`);
+    }
+}
+execAndLog(`git commit -a -m "v${releaseVersion}"`);
+execAndLog(`git tag v${releaseVersion}`);
+execAndLog(`git push origin master --tags`);

--- a/scripts/tslint.json
+++ b/scripts/tslint.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../tslint.json",
+  "rules": {
+    "no-implicit-dependencies": {
+      "options": "dev"
+    }
+  }
+}

--- a/scripts/util.ts
+++ b/scripts/util.ts
@@ -1,0 +1,53 @@
+import * as cp from 'child_process';
+import * as fs from 'fs';
+
+export interface Dependencies {
+    [name: string]: string;
+}
+
+export interface PackageData {
+    name: string;
+    version: string;
+    private?: boolean;
+    dependencies?: Dependencies;
+    devDependencies?: Dependencies;
+    peerDependencies?: Dependencies;
+}
+
+export function getLastRelaseTag() {
+    return cp.execSync('git describe --tags --match=v*.*.* --abbrev=0', {encoding: 'utf8'}).trim();
+}
+
+export function getPackages() {
+    const packages = new Map(
+        fs.readdirSync('packages').map((name): [string, PackageData] => {
+            return [name, require(`../packages/${name}/package.json`)];
+        }),
+    );
+    const publicPackages = new Map(Array.from(packages).filter((v) => !v[1].private));
+    return {
+        packages,
+        publicPackages,
+    };
+}
+
+export function getChangedPackageNames(startRev: string, packageNames: Iterable<string>) {
+    const diff = cp.execSync(
+        `git diff ${startRev} --name-only -z --no-color -- packages/${Array.from(packageNames).join(' packages/')}`,
+        {encoding: 'utf8'},
+    );
+    const result = new Set<string>();
+    for (const file of diff.split('\0'))
+        if (file)
+            result.add(file.split(/[/\\]/)[1]);
+    return result;
+}
+
+export function writeManifest(path: string, content: PackageData) {
+    fs.writeFileSync(path, JSON.stringify(content, undefined, 2) + '\n');
+}
+
+export function execAndLog(command: string) {
+    console.log(`> ${command}`);
+    console.log(cp.execSync(command, {encoding: 'utf8'}));
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3026,6 +3026,10 @@ semver-diff@^2.0.0:
   version "5.4.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.4.1.tgz#e059c09d8571f0540823733433505d3a2f00b18e"
 
+semver@^5.5.0:
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.0.tgz#dc4bbc7a6ca9d916dee5d43516f0092b58f7b8ab"
+
 serialize-error@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/serialize-error/-/serialize-error-2.1.0.tgz#50b679d5635cdf84667bdc8e59af4e5b81d5f60a"


### PR DESCRIPTION
#### Checklist

- [ ] Fixes: #
- [ ] Added or updated tests / baselines
- [ ] Documentation update

#### Overview of change 
Refactor nightly release script to extract some common functions.

Add release script for minor and major versions. Dependencies in package.json are automatically updated.
The version in the root package.json is used as the new version of all changed packages. All packages are released if this is a major release.
The root package.json's version is then updated to the next minor version (for nightlies).