### PR TITLE
bifrost: enforce failures for the same file only

### DIFF
--- a/packages/bifrost/src/index.ts
+++ b/packages/bifrost/src/index.ts
@@ -39,13 +39,18 @@ export function wrapTslintRule(Rule: TSLint.RuleConstructor, name: string): Rule
             } else {
                 result = this.delegate.apply(this.sourceFile);
             }
-            for (const failure of result)
+            const {fileName} = this.sourceFile;
+            for (const failure of result) {
+                if (failure.getFileName() !== fileName)
+                    throw new Error('Adding failures for a different SourceFile is not supported. '
+                        + `Expected '${fileName}' but received '${failure.getFileName()}' from rule '${name}'.`);
                 this.addFailure(
                     failure.getStartPosition().getPosition(),
                     failure.getEndPosition().getPosition(),
                     failure.getFailure(),
                     arrayify(failure.getFix()).map((r) => ({start: r.start, end: r.end, text: r.text})),
                 );
+            }
         }
     };
 }

--- a/packages/bifrost/test/rule.spec.ts
+++ b/packages/bifrost/test/rule.spec.ts
@@ -143,4 +143,20 @@ test('applies rules correctly', (t) => {
         }
     }
     new (wrapTslintRule(DisabledRule, 'disabled'))(context).apply();
+
+    class WrongFileFailureRule extends TSLint.Rules.AbstractRule {
+        public apply() {
+            return [new TSLint.RuleFailure(
+                ts.createSourceFile('other.ts', '', ts.ScriptTarget.Latest),
+                0,
+                0,
+                '',
+                '',
+            )];
+        }
+    }
+    t.throws(
+        () => new (wrapTslintRule(WrongFileFailureRule, 'wrong-file'))(context).apply(),
+        "Adding failures for a different SourceFile is not supported. Expected 'foo.ts' but received 'other.ts' from rule 'wrong-file'.",
+    );
 });


### PR DESCRIPTION
#### Checklist

- [ ] Fixes: #
- [x] Added or updated tests / baselines
- [ ] Documentation update

#### Overview of change 
This change enforces all TSLint rule failures to belong to the same SourceFile as the one currently linted.
The only rules package that would violate that restriction is Codelyzer AFAICT.