### PR TITLE
Fix pattern matching in processed Program

### DIFF
--- a/packages/wotan/package.json
+++ b/packages/wotan/package.json
@@ -41,7 +41,6 @@
     "@types/resolve": "^0.0.6",
     "@types/rimraf": "^2.0.2",
     "@types/semver": "^5.4.0",
-    "@types/to-absolute-glob": "^2.0.0",
     "escape-string-regexp": "^1.0.5",
     "rimraf": "^2.6.2"
   },

--- a/packages/wotan/package.json
+++ b/packages/wotan/package.json
@@ -60,7 +60,6 @@
     "reflect-metadata": "^0.1.12",
     "resolve": "^1.5.0",
     "semver": "^5.4.1",
-    "to-absolute-glob": "^2.0.1",
     "tslib": "^1.8.1",
     "tsutils": "^2.20.0"
   },

--- a/packages/wotan/test/conformance/runner.spec.ts
+++ b/packages/wotan/test/conformance/runner.spec.ts
@@ -4,7 +4,6 @@ import { Container, injectable } from 'inversify';
 import { CORE_DI_MODULE } from '../../src/di/core.module';
 import { DEFAULT_DI_MODULE } from '../../src/di/default.module';
 import { Runner } from '../../src/runner';
-import { unixifyPath } from '../../src/utils';
 import * as path from 'path';
 import { NodeFileSystem } from '../../src/services/default/file-system';
 import { FileSystem, MessageHandler, DirectoryService } from '../../src/types';
@@ -53,7 +52,7 @@ test('throws error on file not included in project', (t) => {
             fix: false,
             extensions: undefined,
         })),
-        `'${unixifyPath(path.resolve('packages/wotan/non-existent.ts'))}' is not included in the project.`,
+        "'non-existent.ts' is not included in the project.",
     );
 });
 

--- a/packages/wotan/test/integration/processors/prefixed/project.test.json
+++ b/packages/wotan/test/integration/processors/prefixed/project.test.json
@@ -1,3 +1,4 @@
 {
-  "project": "."
+  "project": ".",
+  "files": ["foo.test", "other.test"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1377,12 +1377,6 @@ expand-range@^1.8.1:
   dependencies:
     fill-range "^2.1.0"
 
-extend-shallow@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/extend-shallow/-/extend-shallow-2.0.1.tgz#51af7d614ad9a9f610ea1bafbb989d6b1c56890f"
-  dependencies:
-    is-extendable "^0.1.0"
-
 extend@~3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.1.tgz#a755ea7bc1adfcc5a31ce7e762dbaadc5e636444"
@@ -1846,13 +1840,6 @@ irregular-plurals@^1.0.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/irregular-plurals/-/irregular-plurals-1.4.0.tgz#2ca9b033651111855412f16be5d77c62a458a766"
 
-is-absolute@^0.2.5:
-  version "0.2.6"
-  resolved "https://registry.yarnpkg.com/is-absolute/-/is-absolute-0.2.6.tgz#20de69f3db942ef2d87b9c2da36f172235b1b5eb"
-  dependencies:
-    is-relative "^0.2.1"
-    is-windows "^0.2.0"
-
 is-arrayish@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
@@ -1901,7 +1888,7 @@ is-error@^2.2.0:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/is-error/-/is-error-2.2.1.tgz#684a96d84076577c98f4cdb40c6d26a5123bf19c"
 
-is-extendable@^0.1.0, is-extendable@^0.1.1:
+is-extendable@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/is-extendable/-/is-extendable-0.1.1.tgz#62b110e289a471418e3ec36a617d472e301dfc89"
 
@@ -2028,12 +2015,6 @@ is-regex@^1.0.4:
   dependencies:
     has "^1.0.1"
 
-is-relative@^0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/is-relative/-/is-relative-0.2.1.tgz#d27f4c7d516d175fb610db84bbeef23c3bc97aa5"
-  dependencies:
-    is-unc-path "^0.1.1"
-
 is-retry-allowed@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz#11a060568b67339444033d0125a61a20d564fb34"
@@ -2050,12 +2031,6 @@ is-typedarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
 
-is-unc-path@^0.1.1:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/is-unc-path/-/is-unc-path-0.1.2.tgz#6ab053a72573c10250ff416a3814c35178af39b9"
-  dependencies:
-    unc-path-regex "^0.1.0"
-
 is-url@^1.2.1:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/is-url/-/is-url-1.2.2.tgz#498905a593bf47cc2d9e7f738372bbf7696c7f26"
@@ -2063,10 +2038,6 @@ is-url@^1.2.1:
 is-utf8@^0.2.0, is-utf8@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"
-
-is-windows@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-0.2.0.tgz#de1aa6d63ea29dd248737b69f1ff8b8002d2108c"
 
 isarray@1.0.0, isarray@~1.0.0:
   version "1.0.0"
@@ -3552,14 +3523,6 @@ timed-out@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/timed-out/-/timed-out-4.0.1.tgz#f32eacac5a175bea25d7fab565ab3ed8741ef56f"
 
-to-absolute-glob@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/to-absolute-glob/-/to-absolute-glob-2.0.1.tgz#70c375805b9e3105e899ee8dbdd6a9aa108f407b"
-  dependencies:
-    extend-shallow "^2.0.1"
-    is-absolute "^0.2.5"
-    is-negated-glob "^1.0.0"
-
 to-fast-properties@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-1.0.3.tgz#b83571fa4d8c25b82e231b06e3a3055de4ca1a47"
@@ -3683,10 +3646,6 @@ uid-number@^0.0.6:
 uid2@0.0.3:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/uid2/-/uid2-0.0.3.tgz#483126e11774df2f71b8b639dcd799c376162b82"
-
-unc-path-regex@^0.1.0:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/unc-path-regex/-/unc-path-regex-0.1.2.tgz#e73dd3d7b0d7c5ed86fbac6b0ae7d8c6a69d50fa"
 
 underscore.string@~2.2.0rc:
   version "2.2.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -155,10 +155,6 @@
   version "5.4.0"
   resolved "https://registry.yarnpkg.com/@types/semver/-/semver-5.4.0.tgz#f3658535af7f1f502acd6da7daf405ffeb1f7ee4"
 
-"@types/to-absolute-glob@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@types/to-absolute-glob/-/to-absolute-glob-2.0.0.tgz#c9fb8bb16509a8080dcfc6da0a2764bfd95e2dd4"
-
 "@types/void-elements@^3.1.0":
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/@types/void-elements/-/void-elements-3.1.0.tgz#049c29f185dfbb1c0b6197c92844e7df81c27a39"


### PR DESCRIPTION
#### Checklist

- [x] Added or updated tests / baselines

#### Overview of change 
Fix a bug where non-magic patterns were not matched against the original name of a processed file when linting with `--project`.

Also drop to-absolute-glob dependency and show relative pattern in error message.