### PR TITLE
Add processor support to Valtýr

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -5,7 +5,7 @@ The API is designed for dependency injection using [`inversify`](https://github.
 
 ## Services
 
-There are several core services that are provided by Wotan through the ContainerModule `CORE_DI_MODULE`. These services are not meant to be overridden.
+There are several core services that are provided by Wotan through the ContainerModule created by calling `createCoreModule(globalOptions)`. These services are not meant to be overridden.
 
 * `CachedFileSystem` is a wrapper for the low level `FileSystem` service, which caches the file system layout. File contents are not cached.
 * `ConfigurationManager` is the place for everything related to configuration handling. Internally it uses `ConfigurationProvider` to find, load and parse configuration files. Parsed configuration files are cached.
@@ -36,7 +36,7 @@ The example below creates a new DI-Container and binds all necessary services. A
 
 ```ts
 import { Container, BindingScopeEnum, injectable } from 'inversify';
-import { DEFAULT_DI_MODULE, CORE_DI_MODULE, ConfigurationManager, Linter, FileSystem, NodeFileSystem } from '@fimbul/wotan';
+import { createDefaultModule, createCoreModule, ConfigurationManager, Linter, FileSystem, NodeFileSystem } from '@fimbul/wotan';
 import * as ts from 'typescript';
 
 // using RequestScope makes sure there is only one instance of each service and therefore only one cache
@@ -47,7 +47,7 @@ declare class MyFileSystem extends NodeFileSystem {}
 container.bind(FileSystem).to(MyFileSystem);
 
 // load all core services and all default service implementations that are not already bound
-container.load(CORE_DI_MODULE, DEFAULT_DI_MODULE);
+container.load(createCoreModule({}), createDefaultModule());
 
 @injectable()
 class ApiUser {

--- a/packages/valtyr/README.md
+++ b/packages/valtyr/README.md
@@ -39,6 +39,22 @@ There are only minor differences:
 * `stylish` formatter is used by default
 * files of external modules are always excluded while `*.d.ts` in your project are included by default
 
+### Using Processors
+
+Because `tslint.json` has no field to configure processors, you need to configure them in a separate file.
+Create a file named `.fimbullinter.yaml`. If it already exists, simply add the new cofiguration under the `valtyr` key.
+
+The following example shows how to enable a processor for `.vue` files:
+
+```yaml
+valtyr:
+  overrides:
+    - files: "*.vue"
+      processor: "@fimbul/ve"
+```
+
+Note that the configuration for `valtyr` can only contain `overrides`, `settings` and `processor`. Everything else is not supported and will result in an error.
+
 ## Why!?
 
 Why should you use Wotan to execute TSLint rules?
@@ -51,18 +67,18 @@ Why should you use Wotan to execute TSLint rules?
 * Debug output to diagnose crashes.
 * Configuration caching avoids unnecessary work when linting many directories with the same config.
 * Optimized line switch parser finds `tslint:disable` comments faster with less overhead, especially in big files.
+* [Processor support for TSLint rules](https://github.com/palantir/tslint/issues/2099)
 
 ## Caveats
 
 * Additional startup time by loading Wotan and TSLint.
 * Wrapping rules and formatters comes with additional runtime and memory overhead.
-* There's some overhead of the processor machinery that still runs, even though it's unused.
 * For most projects there will be no noticeable difference in performance, smaller projects usually take longer to lint while bigger ones get faster.
 
 ## Difference to [Heimdall](https://github.com/fimbullinter/wotan/blob/master/packages/heimdall/README.md)
 
 This package allows you to use your existing TSLint configuration.
-On the other hand you cannot use any of the builtin rules of Wotan or all those other useful features like processors, overrides, aliases, etc.
+On the other hand you cannot use any of the builtin rules of Wotan or all those other useful features like overrides, aliases, etc.
 If you want to lint with your existing TSLint config *and* your new Wotan config, you need to run Wotan twice, which adds a lot of overhead.
 
 Heimdall requires you to rewrite your linter configuration and switch to `.wotanrc.yaml` (or `.wotanrc.json` if you like that better).

--- a/packages/valtyr/package.json
+++ b/packages/valtyr/package.json
@@ -26,7 +26,6 @@
     "tslint.json"
   ],
   "devDependencies": {
-    "@fimbul/wotan": "^0.2.0",
     "reflect-metadata": "^0.1.12"
   },
   "peerDependencies": {

--- a/packages/valtyr/test/fixtures/.fimbullinter.yaml
+++ b/packages/valtyr/test/fixtures/.fimbullinter.yaml
@@ -1,0 +1,4 @@
+valtyr:
+  overrides:
+    - files: "*.vue"
+      processor: "@fimbul/ve"

--- a/packages/valtyr/test/fixtures/processed.vue
+++ b/packages/valtyr/test/fixtures/processed.vue
@@ -1,0 +1,9 @@
+<template>
+    <input type="text">
+</template>
+<script lang="ts">
+import Vue from 'vue'
+export default Vue.extend({});
+</script>
+<style>
+</style>

--- a/packages/valtyr/test/module.spec.ts
+++ b/packages/valtyr/test/module.spec.ts
@@ -2,21 +2,21 @@ import test from 'ava';
 import * as cp from 'child_process';
 import * as path from 'path';
 
-function execCli(...args: string[]): Promise<{err: Error | null, stdout: string, stderr: string, code: number}> {
+function execCli(args: string[], cwd: string): Promise<{err: Error | null, stdout: string, stderr: string, code: number}> {
     interface ErrorWithCode extends Error {
         code: number;
     }
     return new Promise((r) => {
         cp.exec(
-            `${path.normalize('./node_modules/.bin/wotan')} '${args.join("' '")}'`,
-            {cwd: 'packages/valtyr'},
+            `${path.resolve('./node_modules/.bin/wotan')} '${args.join("' '")}'`,
+            {cwd},
             (err, stdout, stderr) => r({err, stdout, stderr, code: err ? (<ErrorWithCode>err).code : 0}),
         );
     });
 }
 
 test('can be used with --module flag', async (t) => {
-    const result = await execCli('-m', '.', '-f', 'prose', 'test/fixtures/*', 'test/fixtures/.*');
+    const result = await execCli(['-m', '.', '-f', 'prose', 'test/fixtures/*', 'test/fixtures/.*'], 'packages/valtyr');
     t.is(result.code, 2);
     t.is(result.stderr, '');
     t.is(result.stdout.trim(), `ERROR: ${resolve('.dotfile.ts')}[1, 1]: test message
@@ -28,6 +28,14 @@ WARNING: ${resolve('myRuleRule.js')}[5, 78]: Missing semicolon
 WARNING: ${resolve('myRuleRule.js')}[7, 2]: Missing semicolon
 ERROR: ${resolve('test.tsx')}[1, 1]: test message
 WARNING: ${resolve('test.tsx')}[2, 1]: ' should be "`);
+});
+
+test('load processor config from .fimbullinter.yaml', async (t) => {
+    const result = await execCli(['-m', '../..', '-f', 'prose', '*.vue'], 'packages/valtyr/test/fixtures');
+    t.is(result.stderr, '');
+    t.is(result.code, 2);
+    t.is(result.stdout.trim(), `ERROR: ${resolve('processed.vue')}[4, 19]: test message
+WARNING: ${resolve('processed.vue')}[5, 17]: ' should be "`);
 });
 
 function resolve(p: string) {

--- a/packages/wotan/src/commands.ts
+++ b/packages/wotan/src/commands.ts
@@ -8,8 +8,8 @@ import chalk from 'chalk';
 import { RuleTestHost, createBaseline, createBaselineDiff, RuleTester, BaselineKind } from './test';
 import { FormatterLoader } from './services/formatter-loader';
 import { Container, injectable, BindingScopeEnum, ContainerModule } from 'inversify';
-import { CORE_DI_MODULE } from './di/core.module';
-import { DEFAULT_DI_MODULE } from './di/default.module';
+import { createCoreModule } from './di/core.module';
+import { createDefaultModule } from './di/default.module';
 import { ConfigurationManager } from './services/configuration-manager';
 import { CachedFileSystem } from './services/cached-file-system';
 import * as glob from 'glob';
@@ -72,7 +72,6 @@ export async function runCommand(command: Command, diContainer?: Container, glob
             break;
         case CommandName.Save:
             container.bind(AbstractCommandRunner).to(SaveCommandRunner);
-            container.bind(GlobalOptions).toConstantValue(globalOptions);
             break;
         case CommandName.Validate:
             container.bind(AbstractCommandRunner).to(ValidateCommandRunner);
@@ -88,7 +87,7 @@ export async function runCommand(command: Command, diContainer?: Container, glob
         default:
             return assertNever(command);
     }
-    container.load(CORE_DI_MODULE, DEFAULT_DI_MODULE);
+    container.load(createCoreModule(globalOptions), createDefaultModule());
     const commandRunner = container.get(AbstractCommandRunner);
     return commandRunner.run(command);
 }

--- a/packages/wotan/src/di/core.module.ts
+++ b/packages/wotan/src/di/core.module.ts
@@ -7,15 +7,19 @@ import { Linter } from '../linter';
 import { Runner } from '../runner';
 import { ProcessorLoader } from '../services/processor-loader';
 import { RuleTester } from '../test';
+import { GlobalOptions } from '../types';
 
-export const CORE_DI_MODULE = new ContainerModule((bind) => {
-    bind(CachedFileSystem).toSelf();
-    bind(ConfigurationManager).toSelf();
-    bind(FormatterLoader).toSelf();
-    bind(RuleLoader).toSelf();
-    bind(ProcessorLoader).toSelf();
-    bind(Linter).toSelf();
-    bind(Runner).toSelf();
-    bind(RuleTester).toSelf();
-    bind<interfaces.Container>(Container).toDynamicValue((context) => context.container);
-});
+export function createCoreModule(globalOptions: GlobalOptions) {
+    return new ContainerModule((bind) => {
+        bind(CachedFileSystem).toSelf();
+        bind(ConfigurationManager).toSelf();
+        bind(FormatterLoader).toSelf();
+        bind(RuleLoader).toSelf();
+        bind(ProcessorLoader).toSelf();
+        bind(Linter).toSelf();
+        bind(Runner).toSelf();
+        bind(RuleTester).toSelf();
+        bind<interfaces.Container>(Container).toDynamicValue((context) => context.container);
+        bind(GlobalOptions).toConstantValue(globalOptions);
+    });
+}

--- a/packages/wotan/src/di/default.module.ts
+++ b/packages/wotan/src/di/default.module.ts
@@ -22,27 +22,29 @@ import { DefaultDeprecationHandler } from '../services/default/deprecation-handl
 import { DefaultConfigurationProvider } from '../services/default/configuration-provider';
 import { LineSwitchParser, DefaultLineSwitchParser, LineSwitchFilterFactory } from '../services/default/line-switches';
 
-export const DEFAULT_DI_MODULE = new ContainerModule((bind, _unbind, isBound) => {
-    if (!isBound(FormatterLoaderHost))
-        bind(FormatterLoaderHost).to(NodeFormatterLoader);
-    if (!isBound(RuleLoaderHost))
-        bind(RuleLoaderHost).to(NodeRuleLoader);
-    if (!isBound(Resolver))
-        bind(Resolver).to(NodeResolver);
-    if (!isBound(CacheFactory))
-        bind(CacheFactory).to(DefaultCacheFactory);
-    if (!isBound(FileSystem))
-        bind(FileSystem).to(NodeFileSystem);
-    if (!isBound(MessageHandler))
-        bind(MessageHandler).to(ConsoleMessageHandler);
-    if (!isBound(DeprecationHandler))
-        bind(DeprecationHandler).to(DefaultDeprecationHandler);
-    if (!isBound(DirectoryService))
-        bind(DirectoryService).to(NodeDirectoryService);
-    if (!isBound(ConfigurationProvider))
-        bind(ConfigurationProvider).to(DefaultConfigurationProvider);
-    if (!isBound(FailureFilterFactory))
-        bind(FailureFilterFactory).to(LineSwitchFilterFactory);
-    if (!isBound(LineSwitchParser))
-        bind(LineSwitchParser).to(DefaultLineSwitchParser);
-});
+export function createDefaultModule() {
+    return new ContainerModule((bind, _unbind, isBound) => {
+        if (!isBound(FormatterLoaderHost))
+            bind(FormatterLoaderHost).to(NodeFormatterLoader);
+        if (!isBound(RuleLoaderHost))
+            bind(RuleLoaderHost).to(NodeRuleLoader);
+        if (!isBound(Resolver))
+            bind(Resolver).to(NodeResolver);
+        if (!isBound(CacheFactory))
+            bind(CacheFactory).to(DefaultCacheFactory);
+        if (!isBound(FileSystem))
+            bind(FileSystem).to(NodeFileSystem);
+        if (!isBound(MessageHandler))
+            bind(MessageHandler).to(ConsoleMessageHandler);
+        if (!isBound(DeprecationHandler))
+            bind(DeprecationHandler).to(DefaultDeprecationHandler);
+        if (!isBound(DirectoryService))
+            bind(DirectoryService).to(NodeDirectoryService);
+        if (!isBound(ConfigurationProvider))
+            bind(ConfigurationProvider).to(DefaultConfigurationProvider);
+        if (!isBound(FailureFilterFactory))
+            bind(FailureFilterFactory).to(LineSwitchFilterFactory);
+        if (!isBound(LineSwitchParser))
+            bind(LineSwitchParser).to(DefaultLineSwitchParser);
+    });
+}

--- a/packages/wotan/src/project-host.ts
+++ b/packages/wotan/src/project-host.ts
@@ -6,6 +6,9 @@ import { FileKind, CachedFileSystem } from './services/cached-file-system';
 import { Configuration, AbstractProcessor } from './types';
 import { bind } from 'bind-decorator';
 import { ConfigurationManager } from './services/configuration-manager';
+import debug = require('debug');
+
+const log = debug('wotan:projectHost');
 
 // @internal
 export interface ProcessedFileInfo {
@@ -45,7 +48,8 @@ export class ProjectHost implements ts.CompilerHost {
     private tryFindConfig(file: string) {
         try {
             return this.configManager.find(file);
-        } catch {
+        } catch (e) {
+            log("Error while loading configuration for '%s': %s", file, e.message);
             return;
         }
     }

--- a/packages/wotan/test/conformance/commands.spec.ts
+++ b/packages/wotan/test/conformance/commands.spec.ts
@@ -8,8 +8,8 @@ import * as path from 'path';
 import { unixifyPath, format } from '../../src/utils';
 import * as escapeRegex from 'escape-string-regexp';
 import { DefaultCacheFactory } from '../../src/services/default/cache-factory';
-import { CORE_DI_MODULE } from '../../src/di/core.module';
-import { DEFAULT_DI_MODULE } from '../../src/di/default.module';
+import { createCoreModule } from '../../src/di/core.module';
+import { createDefaultModule } from '../../src/di/default.module';
 
 test('ShowCommand', async (t) => {
     const container = new Container();
@@ -241,7 +241,7 @@ test('SaveCommand', async (t) => {
             error() { throw new Error(); },
         };
         container.bind(MessageHandler).toConstantValue(logger);
-        container.load(CORE_DI_MODULE, DEFAULT_DI_MODULE);
+        container.load(createCoreModule({}), createDefaultModule());
 
         await runCommand(command, container, defaults);
         return {

--- a/packages/wotan/test/conformance/configuration.spec.ts
+++ b/packages/wotan/test/conformance/configuration.spec.ts
@@ -22,8 +22,8 @@ import { DefaultConfigurationProvider } from '../../src/services/default/configu
 import { ConfigurationError } from '../../src/error';
 import { NodeFileSystem } from '../../src/services/default/file-system';
 import { ConsoleMessageHandler } from '../../src/services/default/message-handler';
-import { CORE_DI_MODULE } from '../../src/di/core.module';
-import { DEFAULT_DI_MODULE } from '../../src/di/default.module';
+import { createCoreModule } from '../../src/di/core.module';
+import { createDefaultModule } from '../../src/di/default.module';
 
 // tslint:disable:no-null-keyword
 
@@ -41,7 +41,7 @@ test('ConfigurationManager', (t) => {
         },
     };
     container.bind(ConfigurationProvider).toConstantValue(configProvider);
-    container.load(CORE_DI_MODULE, DEFAULT_DI_MODULE);
+    container.load(createCoreModule({}), createDefaultModule());
 
     const cm = container.get(ConfigurationManager);
     t.throws(

--- a/packages/wotan/test/conformance/runner.spec.ts
+++ b/packages/wotan/test/conformance/runner.spec.ts
@@ -1,8 +1,8 @@
 import 'reflect-metadata';
 import test from 'ava';
 import { Container, injectable } from 'inversify';
-import { CORE_DI_MODULE } from '../../src/di/core.module';
-import { DEFAULT_DI_MODULE } from '../../src/di/default.module';
+import { createCoreModule } from '../../src/di/core.module';
+import { createDefaultModule } from '../../src/di/default.module';
 import { Runner } from '../../src/runner';
 import * as path from 'path';
 import { NodeFileSystem } from '../../src/services/default/file-system';
@@ -14,7 +14,7 @@ const directories: DirectoryService = {
 test('throws error on non-existing file', (t) => {
     const container = new Container();
     container.bind(DirectoryService).toConstantValue(directories);
-    container.load(CORE_DI_MODULE, DEFAULT_DI_MODULE);
+    container.load(createCoreModule({}), createDefaultModule());
     const runner = container.get(Runner);
     t.throws(
         () => Array.from(runner.lintCollection({
@@ -37,7 +37,7 @@ test('throws error on non-existing file', (t) => {
 test('throws error on file not included in project', (t) => {
     const container = new Container();
     container.bind(DirectoryService).toConstantValue(directories);
-    container.load(CORE_DI_MODULE, DEFAULT_DI_MODULE);
+    container.load(createCoreModule({}), createDefaultModule());
     const runner = container.get(Runner);
     t.throws(
         () => Array.from(runner.lintCollection({
@@ -72,7 +72,7 @@ test('throws if no tsconfig.json can be found', (t) => {
         }
     }
     container.bind(FileSystem).to(MockFileSystem);
-    container.load(CORE_DI_MODULE, DEFAULT_DI_MODULE);
+    container.load(createCoreModule({}), createDefaultModule());
     const runner = container.get(Runner);
     const {root} = path.parse(process.cwd());
     t.throws(
@@ -144,7 +144,7 @@ test('reports errors while parsing tsconfig.json', (t) => {
         }
     }
     container.bind(FileSystem).to(MockFileSystem);
-    container.load(CORE_DI_MODULE, DEFAULT_DI_MODULE);
+    container.load(createCoreModule({}), createDefaultModule());
     const runner = container.get(Runner);
 
     t.throws(


### PR DESCRIPTION
#### Checklist

- [x] Added or updated tests / baselines
- [x] Documentation update

#### Overview of change 
Allows configuring processors for Valtýr in `.fimbullinter.yaml`