### PR TITLE
add new rule: prefer-number-isnan

### DIFF
--- a/baselines/packages/wotan/test/rules/prefer-number-isnan/es5/declaration.d.ts.lint
+++ b/baselines/packages/wotan/test/rules/prefer-number-isnan/es5/declaration.d.ts.lint
@@ -1,0 +1,3 @@
+declare namespace foo {
+    function isNaN(p: number): boolean;
+}

--- a/baselines/packages/wotan/test/rules/prefer-number-isnan/es5/test.ts.lint
+++ b/baselines/packages/wotan/test/rules/prefer-number-isnan/es5/test.ts.lint
@@ -1,0 +1,23 @@
+declare let num: number;
+declare function get<T>(): T;
+
+"isNaN";
+
+Number.isNaN(1);
+// isNaN
+isNaN(num);
+isNaN(1);
+isNaN(1 + 1);
+!isNaN(get<1 | 2>());
+
+Object.assign(isNaN);
+
+isNaN();
+isNaN(get<any>());
+
+function generic<T extends number, U extends 1 | 2, V extends T | U, W>(p1: T, p2: U, p3: V, p4: W) {
+    isNaN(p1);
+    isNaN(p2);
+    isNaN(p3);
+    isNaN(p4);
+}

--- a/baselines/packages/wotan/test/rules/prefer-number-isnan/esnext/declaration.d.ts.lint
+++ b/baselines/packages/wotan/test/rules/prefer-number-isnan/esnext/declaration.d.ts.lint
@@ -1,0 +1,3 @@
+declare namespace foo {
+    function isNaN(p: number): boolean;
+}

--- a/baselines/packages/wotan/test/rules/prefer-number-isnan/esnext/test.ts
+++ b/baselines/packages/wotan/test/rules/prefer-number-isnan/esnext/test.ts
@@ -1,0 +1,23 @@
+declare let num: number;
+declare function get<T>(): T;
+
+"isNaN";
+
+Number.isNaN(1);
+// isNaN
+Number.isNaN(num);
+Number.isNaN(1);
+Number.isNaN(1 + 1);
+!Number.isNaN(get<1 | 2>());
+
+Object.assign(isNaN);
+
+isNaN();
+isNaN(get<any>());
+
+function generic<T extends number, U extends 1 | 2, V extends T | U, W>(p1: T, p2: U, p3: V, p4: W) {
+    Number.isNaN(p1);
+    Number.isNaN(p2);
+    Number.isNaN(p3);
+    isNaN(p4);
+}

--- a/baselines/packages/wotan/test/rules/prefer-number-isnan/esnext/test.ts.lint
+++ b/baselines/packages/wotan/test/rules/prefer-number-isnan/esnext/test.ts.lint
@@ -1,0 +1,30 @@
+declare let num: number;
+declare function get<T>(): T;
+
+"isNaN";
+
+Number.isNaN(1);
+// isNaN
+isNaN(num);
+~~~~~       [error prefer-number-isnan: Prefer 'Number.isNaN' over 'isNaN'.]
+isNaN(1);
+~~~~~     [error prefer-number-isnan: Prefer 'Number.isNaN' over 'isNaN'.]
+isNaN(1 + 1);
+~~~~~         [error prefer-number-isnan: Prefer 'Number.isNaN' over 'isNaN'.]
+!isNaN(get<1 | 2>());
+ ~~~~~                [error prefer-number-isnan: Prefer 'Number.isNaN' over 'isNaN'.]
+
+Object.assign(isNaN);
+
+isNaN();
+isNaN(get<any>());
+
+function generic<T extends number, U extends 1 | 2, V extends T | U, W>(p1: T, p2: U, p3: V, p4: W) {
+    isNaN(p1);
+    ~~~~~      [error prefer-number-isnan: Prefer 'Number.isNaN' over 'isNaN'.]
+    isNaN(p2);
+    ~~~~~      [error prefer-number-isnan: Prefer 'Number.isNaN' over 'isNaN'.]
+    isNaN(p3);
+    ~~~~~      [error prefer-number-isnan: Prefer 'Number.isNaN' over 'isNaN'.]
+    isNaN(p4);
+}

--- a/packages/wotan/README.md
+++ b/packages/wotan/README.md
@@ -56,6 +56,7 @@ Rule | Description | Difference to TSLint rule / Why you should use it
 `no-nan-compare` | Don't compare with `NaN`, use `isNaN(number)` or `Number.isNaN(number)` instead. | Performance!
 `no-useless-assertion` | Detects type assertions that don't change the type or are not necessary in the first place. *requires type information* | TSLint's `no-unnecessary-type-assertion` does not detect assertions needed to silence the compiler warning `Variable ... is used before being assigned.` The Wotan builtin rule also checks whether the assertion is necessary at all or the receiver accepts the original type.
 `no-useless-initializer` | Detects unnecessary initialization with `undefined`. | TSLint's rule `no-unnecessary-initializer` doesn't fix all parameter initializers and gives false positives for destructuring.
+`prefer-number-isnan` | Prefer ES2015's `Number.isNaN` over the global `isNaN` mainly for performance. *requires type information* | No similar rule in TSLint.
 `prefer-object-spread` | Prefer object spread over `Object.assign` for copying properties to a new object. | Performance, and better handling of parens in fixer.
 `syntaxcheck` | Reports syntax errors as lint errors. This rule is **not** enabled in `wotan:recommended`. *requires type information* | Used to be part of the deprecated `tslint --type-check`
 `trailing-newline` | Requires a line break at the end of each file. | Nothing fancy here :(

--- a/packages/wotan/configs/recommended.yaml
+++ b/packages/wotan/configs/recommended.yaml
@@ -14,6 +14,7 @@ rules:
   no-unused-label: error
   no-useless-assertion: error
   no-useless-initializer: error
+  prefer-number-isnan: error
   prefer-object-spread: error
   trailing-newline: error
   try-catch-return-await: error

--- a/packages/wotan/src/argparse.ts
+++ b/packages/wotan/src/argparse.ts
@@ -282,7 +282,7 @@ function parseOptionalBooleanOrNumber(args: string[], index: number): {index: nu
                 return {index: index + 1, argument: false};
             default: {
                 const num = parseInt(args[index + 1], 10);
-                if (!isNaN(num))
+                if (!Number.isNaN(num))
                     return {index: index + 1, argument: num};
             }
         }

--- a/packages/wotan/src/rules/prefer-number-isnan.ts
+++ b/packages/wotan/src/rules/prefer-number-isnan.ts
@@ -1,0 +1,58 @@
+import { TypedRule, Replacement } from '../types';
+import * as ts from 'typescript';
+import { WrappedAst, getWrappedNodeAtPosition, isIdentifier, isCallExpression, isTypeVariable, isUnionType } from 'tsutils';
+import * as path from 'path';
+import debug = require('debug');
+
+const log = debug('wotan:rule:prefer-number-isnan');
+
+export class Rule extends TypedRule {
+    public static supports(sourceFile: ts.SourceFile) {
+        return !sourceFile.isDeclarationFile;
+    }
+
+    public apply() {
+        if (!this.supportsNumberIsNaN())
+            return;
+        const re = /\bisNaN\b/g;
+        let wrappedAst: WrappedAst | undefined;
+        for (let match = re.exec(this.sourceFile.text); match !== null; match = re.exec(this.sourceFile.text)) {
+            const {node} = getWrappedNodeAtPosition(wrappedAst || (wrappedAst = this.context.getWrappedAst()), match.index)!;
+            if (!isIdentifier(node) || node.end !== re.lastIndex || node.text !== 'isNaN')
+                continue;
+            const parent = node.parent!;
+            if (isCallExpression(parent) && parent.expression === node && parent.arguments.length === 1)
+                this.checkCall(parent);
+        }
+    }
+
+    private checkCall(node: ts.CallExpression) {
+        const arg = node.arguments[0];
+        // don't complain if parameter is not a number because of the different semantics of Number.isNaN
+        if (!this.isNumberLikeType(this.checker.getTypeAtLocation(arg)))
+            return;
+        const start = node.getStart(this.sourceFile);
+        this.addFailure(start, node.expression.end, "Prefer 'Number.isNaN' over 'isNaN'.", Replacement.append(start, 'Number.'));
+    }
+
+    private isNumberLikeType(type: ts.Type): boolean {
+        if (isTypeVariable(type)) {
+            const base = this.checker.getBaseConstraintOfType(type);
+            if (base === undefined)
+                return false;
+            type = base;
+        }
+        if (type.flags & ts.TypeFlags.NumberLike)
+            return true;
+        return isUnionType(type) && type.types.every(this.isNumberLikeType, this);
+    }
+
+    private supportsNumberIsNaN(): boolean {
+        const libFileDir = path.dirname(ts.getDefaultLibFilePath(this.program.getCompilerOptions()));
+        if (this.program.getSourceFile(path.join(libFileDir, 'lib.es2015.core.d.ts')) === undefined) {
+            log("Project does not contain 'lib.es2015.core.d.ts'");
+            return false;
+        }
+        return true;
+    }
+}

--- a/packages/wotan/src/rules/prefer-number-isnan.ts
+++ b/packages/wotan/src/rules/prefer-number-isnan.ts
@@ -21,18 +21,15 @@ export class Rule extends TypedRule {
             if (!isIdentifier(node) || node.end !== re.lastIndex || node.text !== 'isNaN')
                 continue;
             const parent = node.parent!;
-            if (isCallExpression(parent) && parent.expression === node && parent.arguments.length === 1)
-                this.checkCall(parent);
+            if (isCallExpression(parent) && parent.expression === node && parent.arguments.length === 1 &&
+                this.isNumberLikeType(this.checker.getTypeAtLocation(parent.arguments[0])))
+                this.addFailure(
+                    match.index,
+                    re.lastIndex,
+                    "Prefer 'Number.isNaN' over 'isNaN'.",
+                    Replacement.append(match.index, 'Number.'),
+                );
         }
-    }
-
-    private checkCall(node: ts.CallExpression) {
-        const arg = node.arguments[0];
-        // don't complain if parameter is not a number because of the different semantics of Number.isNaN
-        if (!this.isNumberLikeType(this.checker.getTypeAtLocation(arg)))
-            return;
-        const start = node.getStart(this.sourceFile);
-        this.addFailure(start, node.expression.end, "Prefer 'Number.isNaN' over 'isNaN'.", Replacement.append(start, 'Number.'));
     }
 
     private isNumberLikeType(type: ts.Type): boolean {

--- a/packages/wotan/test/rules/prefer-number-isnan/.wotanrc.yaml
+++ b/packages/wotan/test/rules/prefer-number-isnan/.wotanrc.yaml
@@ -1,0 +1,2 @@
+rules:
+  prefer-number-isnan: error

--- a/packages/wotan/test/rules/prefer-number-isnan/declaration.d.ts
+++ b/packages/wotan/test/rules/prefer-number-isnan/declaration.d.ts
@@ -1,0 +1,3 @@
+declare namespace foo {
+    function isNaN(p: number): boolean;
+}

--- a/packages/wotan/test/rules/prefer-number-isnan/es5.test.json
+++ b/packages/wotan/test/rules/prefer-number-isnan/es5.test.json
@@ -1,0 +1,4 @@
+{
+  "project": "tsconfig.es5.json",
+  "files": ["test.ts"]
+}

--- a/packages/wotan/test/rules/prefer-number-isnan/es5.test.json
+++ b/packages/wotan/test/rules/prefer-number-isnan/es5.test.json
@@ -1,4 +1,4 @@
 {
   "project": "tsconfig.es5.json",
-  "files": ["test.ts"]
+  "files": ["test.ts", "declaration.d.ts"]
 }

--- a/packages/wotan/test/rules/prefer-number-isnan/esnext.test.json
+++ b/packages/wotan/test/rules/prefer-number-isnan/esnext.test.json
@@ -1,0 +1,3 @@
+{
+  "project": "tsconfig.esnext.json"
+}

--- a/packages/wotan/test/rules/prefer-number-isnan/test.ts
+++ b/packages/wotan/test/rules/prefer-number-isnan/test.ts
@@ -1,0 +1,23 @@
+declare let num: number;
+declare function get<T>(): T;
+
+"isNaN";
+
+Number.isNaN(1);
+// isNaN
+isNaN(num);
+isNaN(1);
+isNaN(1 + 1);
+!isNaN(get<1 | 2>());
+
+Object.assign(isNaN);
+
+isNaN();
+isNaN(get<any>());
+
+function generic<T extends number, U extends 1 | 2, V extends T | U, W>(p1: T, p2: U, p3: V, p4: W) {
+    isNaN(p1);
+    isNaN(p2);
+    isNaN(p3);
+    isNaN(p4);
+}

--- a/packages/wotan/test/rules/prefer-number-isnan/tsconfig.es5.json
+++ b/packages/wotan/test/rules/prefer-number-isnan/tsconfig.es5.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "target": "es5"
+  }
+}

--- a/packages/wotan/test/rules/prefer-number-isnan/tsconfig.esnext.json
+++ b/packages/wotan/test/rules/prefer-number-isnan/tsconfig.esnext.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.es5.json",
+  "compilerOptions": {
+    "lib": [
+      "esnext"
+    ]
+  }
+}


### PR DESCRIPTION
#### Checklist

- [x] Fixes: #96
- [x] Added or updated tests / baselines
- [x] Documentation update

#### Overview of change 
This rule needs the TypeChecker to determine if `lib.es2015.core.d.ts` is available, because that's where `Number.isNaN` is declared (in the typical case).

Custom libraries and global augmentations are currently not supported.