### PR TITLE
report errors in tsconfig.json as warnings

### DIFF
--- a/packages/wotan/src/runner.ts
+++ b/packages/wotan/src/runner.ts
@@ -236,8 +236,10 @@ export class Runner {
 
     private createProgram(configFile: string, host: ProjectHost): ts.Program {
         const config = ts.readConfigFile(configFile, (file) => host.readFile(file));
-        if (config.error !== undefined)
+        if (config.error !== undefined) {
             this.logger.warn(ts.formatDiagnostics([config.error], host));
+            config.config = {};
+        }
         const parsed = ts.parseJsonConfigFileContent(
             config.config,
             createParseConfigHost(host),


### PR DESCRIPTION
#### Checklist

- [x] Fixes: #140
- [ ] Added or updated tests / baselines
- [ ] Documentation update

#### Overview of change 
This ensures you can use an older version of typescript for linting, even if the tsconfig contains settings for newer typescript versions.