### PR TITLE
no-misused-generics: detect type parameters that actually mean any

### DIFF
--- a/baselines/packages/mimir/test/no-misused-generics/default/test.ts.lint
+++ b/baselines/packages/mimir/test/no-misused-generics/default/test.ts.lint
@@ -9,8 +9,11 @@ declare function get<T, U extends T = T>(param: T): U;
                         ~~~~~~~~~~~~~~~                [error no-misused-generics: TypeParameter 'U' cannot be inferred from any parameter.]
 declare function get<T>(param: T[]): T;
 declare function get<T extends string, U>(param: Record<T, U>): boolean;
+                     ~~~~~~~~~~~~~~~~                                    [error no-misused-generics: TypeParameter 'T' is not used to enforce a constraint between types and can be replaced with 'string'.]
+                                       ~                                 [error no-misused-generics: TypeParameter 'U' is not used to enforce a constraint between types and can be replaced with 'any'.]
 declare function get<T>(param: <T, U>(param: T) => U): T
                      ~                                   [error no-misused-generics: TypeParameter 'T' cannot be inferred from any parameter.]
+                                ~                        [error no-misused-generics: TypeParameter 'T' is not used to enforce a constraint between types and can be replaced with 'any'.]
                                    ~                     [error no-misused-generics: TypeParameter 'U' cannot be inferred from any parameter.]
 
 function fn<T>(param: string) {
@@ -21,6 +24,7 @@ function fn<T>(param: string) {
 
 declare class C<V> {
     method<T, U>(param: T): U;
+           ~                   [error no-misused-generics: TypeParameter 'T' is not used to enforce a constraint between types and can be replaced with 'any'.]
               ~                [error no-misused-generics: TypeParameter 'U' cannot be inferred from any parameter.]
     prop: <T>() => T;
            ~          [error no-misused-generics: TypeParameter 'T' cannot be inferred from any parameter.]
@@ -30,3 +34,23 @@ declare class C<V> {
  ~                      [error no-misused-generics: TypeParameter 'T' cannot be inferred from any parameter.]
 
 get<string>();
+
+declare function take<T>(param: T): void; // T not used as constraint -> could just be `any`
+                      ~                                                                      [error no-misused-generics: TypeParameter 'T' is not used to enforce a constraint between types and can be replaced with 'any'.]
+declare function take<T extends object>(param: T): void; // could just use `object`
+                      ~~~~~~~~~~~~~~~~                                              [error no-misused-generics: TypeParameter 'T' is not used to enforce a constraint between types and can be replaced with 'object'.]
+declare function take<T, U = T>(param1: T, param2: U): void; // no constraint
+                      ~                                                       [error no-misused-generics: TypeParameter 'T' is not used to enforce a constraint between types and can be replaced with 'any'.]
+                         ~~~~~                                                [error no-misused-generics: TypeParameter 'U' is not used to enforce a constraint between types and can be replaced with 'any'.]
+
+declare function identity<T>(param: T): T; // this is valid as it constrains the return type to the parameter type
+declare function compare<T>(param1: T, param2: T): boolean; // this is valid because it enforces comparable types for both parameters
+declare function compare<T, U extends T>(param1: T, param2: U): boolean; // this is also valid because T constrains U
+
+// type parameters in implementations are always necessary, because they enforce type safety in the function body
+function doStuff<K, V>(map: Map<K, V>, key: K) {
+    let v = map.get(key);
+    v = 1; // this error disappears if V is replaces with `any`
+    map.set(key, v);
+    return v; // signature has implicit return type `V`, but we cannot know that without type information
+}

--- a/packages/mimir/README.md
+++ b/packages/mimir/README.md
@@ -28,7 +28,7 @@ Rule | Description | Difference to TSLint rule / Why you should use it
 `no-debugger` | Ban `debugger;` statements from your production code. | Performance!
 `no-fallthrough` | Prevents unintentional fallthough in `switch` statements from one case to another. If the fallthrough is intended, add a comment that matches `/^\s*falls? ?through\b/i`. | Allows more comment variants such as `fallthrough` or `fall through`.
 `no-inferred-empty-object` | Warns if a type parameter is inferred as `{}` because the compiler cannot find any inference site. | Really checks every type parameter of function, method and constructor calls. Correctly handles type parameters from JSDoc comments. Recognises type parameter defaults on all merged declarations.
-`no-misused-generics` | Detects generic type parameters that cannot be inferred from the functions parameters. | There's no similar TSLint rule.
+`no-misused-generics` | Detects generic type parameters that cannot be inferred from the functions parameters. It also detects generics that don't enforce any constraint between types. | There's no similar TSLint rule.
 `no-nan-compare` | Don't compare with `NaN`, use `isNaN(number)` or `Number.isNaN(number)` instead. | Performance!
 `no-return-await` | Warns for unnecesary `return await foo;` when you can simply `return foo;` | The same as TSLint's rule. I wrote both, but this one is faster.
 `no-unreachable-code` | Warns about statements that will never be executed. Works like TypeScript's dead code detection but doesn't fail compilation because it's a lint error. | TSLint removed their `no-unreachable` rule in v4.0.0.

--- a/packages/mimir/src/rules/no-misused-generics.ts
+++ b/packages/mimir/src/rules/no-misused-generics.ts
@@ -1,6 +1,6 @@
 import { AbstractRule, typescriptOnly } from '@fimbul/ymir';
 import * as ts from 'typescript';
-import { isSignatureDeclaration, collectVariableUsage, VariableInfo } from 'tsutils';
+import { isSignatureDeclaration, collectVariableUsage, VariableInfo, isFunctionWithBody } from 'tsutils';
 
 @typescriptOnly
 export class Rule extends AbstractRule {
@@ -9,20 +9,56 @@ export class Rule extends AbstractRule {
     public apply() {
         for (const node of this.context.getFlatAst())
             if (isSignatureDeclaration(node) && node.typeParameters !== undefined)
-                for (const typeParameter of node.typeParameters)
-                    if (!this.isUsedInParameterTypes(typeParameter, node.parameters))
-                        this.addFailureAtNode(
-                            typeParameter,
-                            `TypeParameter '${typeParameter.name.text}' cannot be inferred from any parameter.`,
-                        );
+                this.checkTypeParameters(node.typeParameters, node);
     }
 
-    private isUsedInParameterTypes(typeParameter: ts.TypeParameterDeclaration, range: ts.TextRange): boolean {
+    private checkTypeParameters(typeParameters: ReadonlyArray<ts.TypeParameterDeclaration>, signature: ts.SignatureDeclaration) {
         if (this.usage === undefined)
             this.usage = collectVariableUsage(this.sourceFile);
-        for (const use of this.usage.get(typeParameter.name)!.uses)
-            if (use.location.pos > range.pos && use.location.pos < range.end)
-                return true;
+        outer: for (const typeParameter of typeParameters) {
+            let usedInParameters = false;
+            let usedInReturnOrExtends = isFunctionWithBody(signature);
+            for (const use of this.usage.get(typeParameter.name)!.uses) {
+                if (use.location.pos > signature.parameters.pos && use.location.pos < signature.parameters.end) {
+                    if (usedInParameters)
+                        continue outer;
+                    usedInParameters = true;
+                } else if (!usedInReturnOrExtends) {
+                    usedInReturnOrExtends = use.location.pos > signature.parameters.end || isUsedInConstraint(use.location, typeParameters);
+                }
+            }
+            if (!usedInParameters) {
+                this.addFailureAtNode(
+                    typeParameter,
+                    `TypeParameter '${typeParameter.name.text}' cannot be inferred from any parameter.`,
+                );
+            } else if (!usedInReturnOrExtends && !this.isConstrainedByOtherTypeParameter(typeParameter, typeParameters)) {
+                this.addFailureAtNode(
+                    typeParameter,
+                    `TypeParameter '${typeParameter.name.text}' is not used to enforce a constraint between types and can be replaced with \
+'${typeParameter.constraint ? typeParameter.constraint.getText(this.sourceFile) : 'any'}'.`,
+                );
+            }
+        }
+    }
+
+    private isConstrainedByOtherTypeParameter(current: ts.TypeParameterDeclaration, all: ReadonlyArray<ts.TypeParameterDeclaration>) {
+        if (current.constraint === undefined)
+            return false;
+        for (const typeParameter of all) {
+            if (typeParameter === current)
+                continue;
+            for (const use of this.usage!.get(typeParameter.name)!.uses)
+                if (use.location.pos >= current.constraint.pos && use.location.pos < current.constraint.end)
+                    return true;
+        }
         return false;
     }
+}
+
+function isUsedInConstraint(use: ts.Identifier, typeParameters: ReadonlyArray<ts.TypeParameterDeclaration>) {
+    for (const typeParameter of typeParameters)
+        if (typeParameter.constraint !== undefined && use.pos >= typeParameter.constraint.pos && use.pos < typeParameter.constraint.end)
+            return true;
+    return false;
 }

--- a/packages/mimir/test/no-misused-generics/test.ts
+++ b/packages/mimir/test/no-misused-generics/test.ts
@@ -20,3 +20,19 @@ declare class C<V> {
 <T>(param): T => null!;
 
 get<string>();
+
+declare function take<T>(param: T): void; // T not used as constraint -> could just be `any`
+declare function take<T extends object>(param: T): void; // could just use `object`
+declare function take<T, U = T>(param1: T, param2: U): void; // no constraint
+
+declare function identity<T>(param: T): T; // this is valid as it constrains the return type to the parameter type
+declare function compare<T>(param1: T, param2: T): boolean; // this is valid because it enforces comparable types for both parameters
+declare function compare<T, U extends T>(param1: T, param2: U): boolean; // this is also valid because T constrains U
+
+// type parameters in implementations are always necessary, because they enforce type safety in the function body
+function doStuff<K, V>(map: Map<K, V>, key: K) {
+    let v = map.get(key);
+    v = 1; // this error disappears if V is replaces with `any`
+    map.set(key, v);
+    return v; // signature has implicit return type `V`, but we cannot know that without type information
+}


### PR DESCRIPTION
#### Checklist

- [x] Fixes: #142 
- [x] Added or updated tests / baselines
- [x] Documentation update

#### Overview of change 
Benefits:
* signatures without TypeParameters are faster to typecheck
* less useless code
* added type safety:
```ts
declare function bad<T extends {prop: string}>(param: T): void;
bad({prop: '', prop2: 2}); // no excess property error

// refactor to
declare function good(param: {prop: string}): void;
good({prop: '', prop2: 2}); // now there is an excess property error
```