### PR TITLE
no-useless-predicate: check literal types

### DIFF
--- a/baselines/packages/mimir/test/no-useless-predicate/default/test.ts.lint
+++ b/baselines/packages/mimir/test/no-useless-predicate/default/test.ts.lint
@@ -233,3 +233,20 @@ const enum E2 {
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  [error no-useless-predicate: Expression is always truthy.]
 !get<E2>();
  ~~~~~~~~~  [error no-useless-predicate: Expression is always truthy.]
+
+const TypeOfString = 'string';
+
+typeof 1 === TypeOfString;
+~~~~~~~~~~~~~~~~~~~~~~~~~  [error no-useless-predicate: Expression is always falsy.]
+
+const enum TypeOf {
+    String = 'string',
+    Number = 'number',
+}
+
+typeof 1 === TypeOf.Number;
+~~~~~~~~~~~~~~~~~~~~~~~~~~  [error no-useless-predicate: Expression is always truthy.]
+typeof 1 === TypeOf.String;
+~~~~~~~~~~~~~~~~~~~~~~~~~~  [error no-useless-predicate: Expression is always falsy.]
+
+typeof true === get<TypeOf>();

--- a/baselines/packages/mimir/test/no-useless-predicate/loose/test.ts.lint
+++ b/baselines/packages/mimir/test/no-useless-predicate/loose/test.ts.lint
@@ -202,3 +202,19 @@ const enum E2 {
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  [error no-useless-predicate: Expression is always truthy.]
 !get<E2>();
  ~~~~~~~~~  [error no-useless-predicate: Expression is always truthy.]
+
+const TypeOfString = 'string';
+
+typeof 1 === TypeOfString;
+~~~~~~~~~~~~~~~~~~~~~~~~~  [error no-useless-predicate: Expression is always falsy.]
+
+const enum TypeOf {
+    String = 'string',
+    Number = 'number',
+}
+
+typeof 1 === TypeOf.Number;
+typeof 1 === TypeOf.String;
+~~~~~~~~~~~~~~~~~~~~~~~~~~  [error no-useless-predicate: Expression is always falsy.]
+
+typeof true === get<TypeOf>();

--- a/packages/mimir/test/no-useless-predicate/test.ts
+++ b/packages/mimir/test/no-useless-predicate/test.ts
@@ -167,3 +167,17 @@ const enum E2 {
 !get<E.Foo | CE.Foo | CSE.Bar>();
 !get<E.Bar | CE.Bar | CSE.Bar>();
 !get<E2>();
+
+const TypeOfString = 'string';
+
+typeof 1 === TypeOfString;
+
+const enum TypeOf {
+    String = 'string',
+    Number = 'number',
+}
+
+typeof 1 === TypeOf.Number;
+typeof 1 === TypeOf.String;
+
+typeof true === get<TypeOf>();


### PR DESCRIPTION
#### Checklist

- [x] Fixes: #148 
- [x] Added or updated tests / baselines
- [ ] Documentation update

#### Overview of change 
Only check literal types. Checking unions of literals seems not to be worth the effort.