### PR TITLE
valtyr: correctly load custom formatters

### DIFF
--- a/packages/valtyr/src/formatter-loader.ts
+++ b/packages/valtyr/src/formatter-loader.ts
@@ -5,11 +5,11 @@ import { wrapTslintFormatter } from '@fimbul/bifrost';
 
 @injectable()
 export class TslintFormatterLoaderHost implements FormatterLoaderHost {
-    public loadCoreFormatter(name: string): FormatterConstructor | undefined {
-        const result = TSLint.findFormatter(name);
-        return result === undefined ? undefined : wrapTslintFormatter(result);
-    }
-    public loadCustomFormatter(): undefined {
-        return;
-    }
+    public loadCoreFormatter = loadFormatter;
+    public loadCustomFormatter = loadFormatter;
+}
+
+function loadFormatter(name: string): FormatterConstructor | undefined {
+    const result = TSLint.findFormatter(name);
+    return result === undefined ? undefined : wrapTslintFormatter(result);
 }

--- a/packages/valtyr/test/formatter-loader.spec.ts
+++ b/packages/valtyr/test/formatter-loader.spec.ts
@@ -23,10 +23,12 @@ test('loads TSLint formatter', (t) => {
         fix: undefined,
     }]});
     t.is(instance.flush!(), 'foo.ts');
+
+    t.not(loader.loadCustomFormatter('fileslist'), undefined);
 });
 
 test('returns undefined if no formatter is found', (t) => {
     const loader = new TslintFormatterLoaderHost();
     t.is(loader.loadCoreFormatter('non-existent-formatter-name'), undefined);
-    t.is(loader.loadCustomFormatter(), undefined);
+    t.is(loader.loadCustomFormatter('./some-formatter'), undefined);
 });


### PR DESCRIPTION
#### Checklist

- [ ] Fixes: #
- [x] Added or updated tests / baselines
- [ ] Documentation update

#### Overview of change 
Previously using custom formatters by relative path was not possible.