### PR TITLE
no-useless-spread: don't fix object spread

### DIFF
--- a/baselines/packages/mimir/test/no-useless-spread/default/test.ts
+++ b/baselines/packages/mimir/test/no-useless-spread/default/test.ts
@@ -6,15 +6,20 @@ console.log('a', 'b', 1, 'c', ...arr, 'd');
 
 let obj = {
   foo: 1,
-   bar: 2, ...someObj ,
+  ...{ bar: 2, ...someObj },
+  ~~~~~~~~~~~~~~~~~~~~~~~~~  [error no-useless-spread: Using the spread operator here is not necessary.]
   baz: 3,
   ...someOtherObject || { bas: 4 }
 };
 
-({foo, bar, ...rest} = obj);
+({foo, .../* comment */{bar, ...rest}} = obj);
+       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~          [error no-useless-spread: Using the spread operator here is not necessary.]
 
 obj = {
-    ...obj
+    ... // comment
+    ~~~~~~~~~~~~~~
+    {...obj}
+~~~~~~~~~~~~ [error no-useless-spread: Using the spread operator here is not necessary.]
 };
 
 console.log();
@@ -29,7 +34,8 @@ let a = [...[,],];
    let a = [1,];
 
 // ({foo: 'foo',});
-   ({foo: 'foo',});
+   ({...{foo: 'foo',},});
+     ~~~~~~~~~~~~~~~~     [error no-useless-spread: Using the spread operator here is not necessary.]
 
 // let a = [];
    let a = [];
@@ -51,3 +57,13 @@ let a = [...[,],];
 
 // console.log();
    console.log();
+
+const named = 'bar';
+// don't fix object spread because of possible duplicate key errors
+let myObj = {
+    ...{foo: 1},
+    ~~~~~~~~~~~  [error no-useless-spread: Using the spread operator here is not necessary.]
+    bar: 1,
+    ...{foo: 2, [named]: 2},
+    ~~~~~~~~~~~~~~~~~~~~~~~  [error no-useless-spread: Using the spread operator here is not necessary.]
+};

--- a/baselines/packages/mimir/test/no-useless-spread/default/test.ts.lint
+++ b/baselines/packages/mimir/test/no-useless-spread/default/test.ts.lint
@@ -72,3 +72,13 @@ let a = [...[,],];
 // console.log();
    console.log(...[],);
                ~~~~~    [error no-useless-spread: Using the spread operator here is not necessary.]
+
+const named = 'bar';
+// don't fix object spread because of possible duplicate key errors
+let myObj = {
+    ...{foo: 1},
+    ~~~~~~~~~~~  [error no-useless-spread: Using the spread operator here is not necessary.]
+    bar: 1,
+    ...{foo: 2, [named]: 2},
+    ~~~~~~~~~~~~~~~~~~~~~~~  [error no-useless-spread: Using the spread operator here is not necessary.]
+};

--- a/packages/mimir/src/rules/no-useless-spread.ts
+++ b/packages/mimir/src/rules/no-useless-spread.ts
@@ -35,24 +35,19 @@ export class Rule extends AbstractRule {
     }
 }
 
-function removeUselessSpread(node: ts.SpreadElement | ts.SpreadAssignment): Replacement | Replacement[] {
-    const list = isArrayLiteralExpression(node.expression)
-        ? node.expression.elements
-        : (<ts.ObjectLiteralExpression>node.expression).properties;
+function removeUselessSpread(node: ts.SpreadElement | ts.SpreadAssignment) {
+    if (node.kind !== ts.SyntaxKind.SpreadElement)
+        return;
 
+    const list = (<ts.ArrayLiteralExpression>node.expression).elements;
     /* Handles edge cases of spread on empty array literals */
-    if (isSpreadElement(node) && isArrayLiteralExpression(node.expression) && list.length === 0)
+    if (list.length === 0)
         return removeUselessSpreadOfEmptyArray(node);
 
-    const replacements = [
+    return [
         Replacement.delete(node.getStart(), node.expression.getStart() + 1),
-        Replacement.delete(node.expression.end - 1, node.expression.end),
+        Replacement.delete(list[list.length - 1].end, node.expression.end),
     ];
-
-    /* Check for trailing commas in array/obj literals */
-    if (list.hasTrailingComma) replacements.push(Replacement.delete(list.end - 1, list.end));
-
-    return replacements;
 }
 
 function removeUselessSpreadOfEmptyArray(node: ts.SpreadElement): Replacement {

--- a/packages/mimir/test/no-useless-spread/test.ts
+++ b/packages/mimir/test/no-useless-spread/test.ts
@@ -52,3 +52,11 @@ let a = [...[,],];
 
 // console.log();
    console.log(...[],);
+
+const named = 'bar';
+// don't fix object spread because of possible duplicate key errors
+let myObj = {
+    ...{foo: 1},
+    bar: 1,
+    ...{foo: 2, [named]: 2},
+};


### PR DESCRIPTION
#### Checklist

- [x] Fixes: #186
- [x] Added or updated tests / baselines
- [ ] Documentation update

#### Overview of change 
Don't fix object spread at all to avoid creating duplicate key errors.

Added a test case for duplicate object keys. Maybe someone wants to fix this later.