### PR TITLE
Extract logic to visit child statements

### DIFF
--- a/baselines/packages/mimir/test/await-async-result/default/test.ts.lint
+++ b/baselines/packages/mimir/test/await-async-result/default/test.ts.lint
@@ -4,6 +4,11 @@ async function isAsync() {
     return 10;
 }
 
+async function async() {
+    async();
+    ~~~~~~~~ [error await-async-result: Return value of async function call was discarded. Did you mean to 'await' its result?]
+}
+
 function notAsync() {
     return 10;
 }
@@ -15,12 +20,22 @@ class Foo {
     async isAsync() {
         return 10;
     }
+
+    /* async */
+    public async anotherAsync() {
+        isAsync();
+        ~~~~~~~~~~ [error await-async-result: Return value of async function call was discarded. Did you mean to 'await' its result?]
+        if (Boolean())
+            this.isAsync();
+            ~~~~~~~~~~~~~~~ [error await-async-result: Return value of async function call was discarded. Did you mean to 'await' its result?]
+    }
+
     notAsync() {
         return 10;
     }
 }
 
-async function test() {
+export async function test() {
     isAsync();
     ~~~~~~~~~~ [error await-async-result: Return value of async function call was discarded. Did you mean to 'await' its result?]
     notAsync();
@@ -57,3 +72,7 @@ returnsThenable();
 let foo = new Foo();
 foo.isAsync();
 foo.notAsync();
+
+async () => isAsync();
+async () => { isAsync(); };
+              ~~~~~~~~~~    [error await-async-result: Return value of async function call was discarded. Did you mean to 'await' its result?]

--- a/packages/mimir/src/rules/await-async-result.ts
+++ b/packages/mimir/src/rules/await-async-result.ts
@@ -1,6 +1,6 @@
 import { TypedRule, excludeDeclarationFiles } from '@fimbul/ymir';
 import { isExpressionStatement, isCallExpression, isThenableType, WrappedAst, getWrappedNodeAtPosition } from 'tsutils';
-import { isAsyncFunction, getChildStatements } from '../utils';
+import { isAsyncFunction, childStatements } from '../utils';
 import * as ts from 'typescript';
 
 @excludeDeclarationFiles
@@ -24,7 +24,7 @@ export class Rule extends TypedRule {
                 this.addFailureAtNode(node, "Return value of async function call was discarded. Did you mean to 'await' its result?");
             return;
         }
-        for (const statement of getChildStatements(node))
+        for (const statement of childStatements(node))
             this.visitStatement(statement);
     }
 }

--- a/packages/mimir/src/rules/await-async-result.ts
+++ b/packages/mimir/src/rules/await-async-result.ts
@@ -1,34 +1,30 @@
 import { TypedRule, excludeDeclarationFiles } from '@fimbul/ymir';
-import { NodeWrap, isFunctionScopeBoundary, isExpressionStatement, isCallExpression, isThenableType } from 'tsutils';
-import { isAsyncFunction } from '../utils';
+import { isExpressionStatement, isCallExpression, isThenableType, WrappedAst, getWrappedNodeAtPosition } from 'tsutils';
+import { isAsyncFunction, getChildStatements } from '../utils';
+import * as ts from 'typescript';
 
 @excludeDeclarationFiles
 export class Rule extends TypedRule {
     public apply() {
-        return this.iterate(this.context.getWrappedAst().next, undefined);
-    }
-
-    private iterate(wrap: NodeWrap, end: NodeWrap | undefined) {
-        do { // iterate as linked list until we find an async function / method
-            if (!isAsyncFunction(wrap.node)) {
-                wrap = wrap.next!;
+        const re = /\basync\b/g;
+        let wrappedAst: WrappedAst | undefined;
+        for (let match = re.exec(this.sourceFile.text); match !== null; match = re.exec(this.sourceFile.text)) {
+            const {node} = getWrappedNodeAtPosition(wrappedAst || (wrappedAst = this.context.getWrappedAst()), match.index)!;
+            if (node.kind !== ts.SyntaxKind.AsyncKeyword || node.end !== re.lastIndex)
                 continue;
-            }
-            wrap.children.forEach(this.visitNode, this); // visit children recursively
-            wrap = wrap.skip!; // continue right after the function
-        } while (wrap !== end);
+            const parent = node.parent!;
+            if (isAsyncFunction(parent))
+                parent.body.statements.forEach(this.visitStatement, this);
+        }
     }
 
-    private visitNode(wrap: NodeWrap) {
-        if (isExpressionStatement(wrap.node)) {
-            if (isCallExpression(wrap.node.expression) && isThenableType(this.checker, wrap.node.expression))
-                this.addFailureAtNode(wrap.node, "Return value of async function call was discarded. Did you mean to 'await' its result?");
-            // ExpressionStatement does not contain other statements (until DoExpressions land in the spec)
-            return this.iterate(wrap.next!, wrap.skip);
+    private visitStatement(node: ts.Statement) {
+        if (isExpressionStatement(node)) {
+            if (isCallExpression(node.expression) && isThenableType(this.checker, node.expression))
+                this.addFailureAtNode(node, "Return value of async function call was discarded. Did you mean to 'await' its result?");
+            return;
         }
-        if (isFunctionScopeBoundary(wrap.node)) // no longer in async function -> iterate as linked list
-            return this.iterate(wrap, wrap.skip);
-
-        return wrap.children.forEach(this.visitNode, this);
+        for (const statement of getChildStatements(node))
+            this.visitStatement(statement);
     }
 }

--- a/packages/mimir/src/rules/no-unused-label.ts
+++ b/packages/mimir/src/rules/no-unused-label.ts
@@ -1,69 +1,35 @@
 import * as ts from 'typescript';
-import { isLabeledStatement, isBreakOrContinueStatement, isFunctionScopeBoundary, NodeWrap } from 'tsutils';
+import { isBreakOrContinueStatement, isLabeledStatement } from 'tsutils';
 import { AbstractRule, Replacement, excludeDeclarationFiles } from '@fimbul/ymir';
-
-interface Label {
-    node: ts.LabeledStatement;
-    name: string;
-    used: boolean;
-}
+import { childStatements } from '../utils';
 
 @excludeDeclarationFiles
 export class Rule extends AbstractRule {
-    private labels: Label[] = [];
-
     public apply() {
-        return this.iterate(this.context.getWrappedAst().next, undefined);
-    }
-
-    private iterate(wrap: NodeWrap, end: NodeWrap | undefined) {
-        do { // iterate as linked list until we find the first labeled statement
-            if (wrap.kind === ts.SyntaxKind.LabeledStatement) {
-                this.visitNode(wrap); // to handle this label we need to recursively call visitNode
-                wrap = wrap.skip!; // continue right after the labeled statement
-            } else {
-                wrap = wrap.next!;
+        for (const node of this.context.getFlatAst()) {
+            if (node.kind === ts.SyntaxKind.LabeledStatement) {
+                const {label, statement} = <ts.LabeledStatement>node;
+                if (!usesLabel(statement, label.text)) {
+                    const start = label.getStart(this.sourceFile);
+                    this.addFailure(
+                        start,
+                        label.end,
+                        `Unused label '${label.text}'.`,
+                        Replacement.delete(start, statement.getStart(this.sourceFile)),
+                    );
+                }
             }
-        } while (wrap !== end);
+        }
     }
+}
 
-    private visitNode(wrap: NodeWrap): void {
-        const {node} = wrap;
-        if (isLabeledStatement(node)) {
-            this.labels.unshift({node, name: node.label.text, used: false});
-            this.visitNode(wrap.children[1]);
-            const label = this.labels.shift()!;
-            if (!label.used)
-                this.fail(label.node);
-            return;
-        }
-        if (isBreakOrContinueStatement(node)) {
-            if (node.label !== undefined) {
-                const name = node.label.text;
-                const label = this.labels.find((l) => l.name === name);
-                if (label !== undefined)
-                    label.used = true;
-            }
-            return;
-        }
-        if (isFunctionScopeBoundary(node)) {
-            const saved = this.labels;
-            this.labels = [];
-            // can iterate as linked list again since there are no active labels to look for
-            this.iterate(wrap.next!, wrap.skip);
-            this.labels = saved;
-            return;
-        }
-        return wrap.children.forEach(this.visitNode, this);
-    }
-
-    private fail(statement: ts.LabeledStatement) {
-        const start = statement.label.getStart(this.sourceFile);
-        this.addFailure(
-            start,
-            statement.label.end,
-            `Unused label '${statement.label.text}'.`,
-            Replacement.delete(start, statement.statement.getStart(this.sourceFile)),
-        );
-    }
+function usesLabel(node: ts.Statement, label: string): boolean {
+    if (isBreakOrContinueStatement(node))
+        return node.label !== undefined && node.label.text === label;
+    if (isLabeledStatement(node))
+        return node.label.text !== label && usesLabel(node.statement, label);
+    for (const statement of childStatements(node))
+        if (usesLabel(statement, label))
+            return true;
+    return false;
 }

--- a/packages/mimir/src/rules/try-catch-return-await.ts
+++ b/packages/mimir/src/rules/try-catch-return-await.ts
@@ -9,7 +9,7 @@ import {
     getWrappedNodeAtPosition,
 } from 'tsutils';
 import * as ts from 'typescript';
-import { isAsyncFunction, getChildStatements } from '../utils';
+import { isAsyncFunction, childStatements } from '../utils';
 
 @excludeDeclarationFiles
 export class Rule extends TypedRule {
@@ -42,7 +42,7 @@ export class Rule extends TypedRule {
         }
         if (node.kind === ts.SyntaxKind.TryStatement)
             this.reported.add(node.pos);
-        for (const statement of getChildStatements(node))
+        for (const statement of childStatements(node))
             this.visitStatement(statement);
     }
 

--- a/packages/mimir/src/utils.ts
+++ b/packages/mimir/src/utils.ts
@@ -23,7 +23,7 @@ export function* switchStatements(context: RuleContext) {
     }
 }
 
-export function isAsyncFunction(node: ts.Node): node is ts.FunctionLikeDeclaration {
+export function isAsyncFunction(node: ts.Node): node is ts.FunctionLikeDeclaration & {body: ts.Block} {
     switch (node.kind) {
         case ts.SyntaxKind.FunctionDeclaration:
         case ts.SyntaxKind.MethodDeclaration:
@@ -31,13 +31,49 @@ export function isAsyncFunction(node: ts.Node): node is ts.FunctionLikeDeclarati
                 return false;
             // falls through
         case ts.SyntaxKind.ArrowFunction:
+            if ((<ts.ArrowFunction>node).body.kind !== ts.SyntaxKind.Block)
+                return false;
+            // falls through
         case ts.SyntaxKind.FunctionExpression:
-            return hasModifier(node.modifiers, ts.SyntaxKind.AsyncKeyword);
+            break;
         default:
             return false;
     }
+    return hasModifier(node.modifiers, ts.SyntaxKind.AsyncKeyword);
 }
 
 export function isVariableReassignment(use: VariableUse) {
     return (use.domain & (UsageDomain.Value | UsageDomain.TypeQuery)) === UsageDomain.Value && isReassignmentTarget(use.location);
+}
+
+export function* getChildStatements(node: ts.Statement) {
+    switch (node.kind) {
+        case ts.SyntaxKind.IfStatement:
+            yield (<ts.IfStatement>node).thenStatement;
+            if ((<ts.IfStatement>node).elseStatement !== undefined)
+                yield (<ts.IfStatement>node).elseStatement!;
+            break;
+        case ts.SyntaxKind.ForStatement:
+        case ts.SyntaxKind.ForOfStatement:
+        case ts.SyntaxKind.ForInStatement:
+        case ts.SyntaxKind.WhileStatement:
+        case ts.SyntaxKind.DoStatement:
+        case ts.SyntaxKind.LabeledStatement:
+        case ts.SyntaxKind.WithStatement:
+            yield (<ts.IterationStatement | ts.LabeledStatement | ts.WithStatement>node).statement;
+            break;
+        case ts.SyntaxKind.SwitchStatement:
+            for (const clause of (<ts.SwitchStatement>node).caseBlock.clauses)
+                yield* clause.statements;
+            break;
+        case ts.SyntaxKind.Block:
+            yield* (<ts.Block>node).statements;
+            break;
+        case ts.SyntaxKind.TryStatement:
+            yield* (<ts.TryStatement>node).tryBlock.statements;
+            if ((<ts.TryStatement>node).catchClause !== undefined)
+                yield* (<ts.TryStatement>node).catchClause!.block.statements;
+            if ((<ts.TryStatement>node).finallyBlock !== undefined)
+                yield* ((<ts.TryStatement>node)).finallyBlock!.statements;
+    }
 }

--- a/packages/mimir/src/utils.ts
+++ b/packages/mimir/src/utils.ts
@@ -46,7 +46,7 @@ export function isVariableReassignment(use: VariableUse) {
     return (use.domain & (UsageDomain.Value | UsageDomain.TypeQuery)) === UsageDomain.Value && isReassignmentTarget(use.location);
 }
 
-export function* getChildStatements(node: ts.Statement) {
+export function* childStatements(node: ts.Statement) {
     switch (node.kind) {
         case ts.SyntaxKind.IfStatement:
             yield (<ts.IfStatement>node).thenStatement;

--- a/packages/mimir/test/await-async-result/test.ts
+++ b/packages/mimir/test/await-async-result/test.ts
@@ -4,6 +4,10 @@ async function isAsync() {
     return 10;
 }
 
+async function async() {
+    async();
+}
+
 function notAsync() {
     return 10;
 }
@@ -15,12 +19,20 @@ class Foo {
     async isAsync() {
         return 10;
     }
+
+    /* async */
+    public async anotherAsync() {
+        isAsync();
+        if (Boolean())
+            this.isAsync();
+    }
+
     notAsync() {
         return 10;
     }
 }
 
-async function test() {
+export async function test() {
     isAsync();
     notAsync();
     returnsPromise();
@@ -53,3 +65,6 @@ returnsThenable();
 let foo = new Foo();
 foo.isAsync();
 foo.notAsync();
+
+async () => isAsync();
+async () => { isAsync(); };


### PR DESCRIPTION
Simplify and optimize `no-unused-label` and `await-async-result`.