### PR TITLE
no-inferred-empty-object: correctly check classes with constructor

### DIFF
--- a/baselines/packages/mimir/test/no-inferred-empty-object/default/test.ts.lint
+++ b/baselines/packages/mimir/test/no-inferred-empty-object/default/test.ts.lint
@@ -155,6 +155,22 @@ new Wrap<number>(1);
 
 wrapped = new Wrap();
 
+class MyWrap<T> {
+    constructor(public param?: T) {}
+}
+
+new MyWrap();
+~~~~~~~~~~~~  [error no-inferred-empty-object: TypeParameter 'T' is inferred as '{}'. Consider adding type arguments to the call.]
+new MyWrap<number>()
+new MyWrap(1);
+
+class MyOtherWrap<T> {
+    constructor() {}
+}
+new MyOtherWrap();
+~~~~~~~~~~~~~~~~~  [error no-inferred-empty-object: TypeParameter 'T' is inferred as '{}'. Consider adding type arguments to the call.]
+new MyOtherWrap<number>();
+
 function getWrapper() {
     return Wrapper;
 }

--- a/packages/mimir/test/no-inferred-empty-object/test.ts
+++ b/packages/mimir/test/no-inferred-empty-object/test.ts
@@ -130,6 +130,20 @@ new Wrap<number>(1);
 
 wrapped = new Wrap();
 
+class MyWrap<T> {
+    constructor(public param?: T) {}
+}
+
+new MyWrap();
+new MyWrap<number>()
+new MyWrap(1);
+
+class MyOtherWrap<T> {
+    constructor() {}
+}
+new MyOtherWrap();
+new MyOtherWrap<number>();
+
 function getWrapper() {
     return Wrapper;
 }


### PR DESCRIPTION
#### Checklist

- [x] Fixes: #195
- [x] Added or updated tests / baselines
- [ ] Documentation update

#### Overview of change 
If the constructor has no type parameters, look on the class declaration.

The change in `getTypeParameters` might also address #194 