### PR TITLE
no-useless-assertion: forbid definite assignment assertion on computed name

### DIFF
--- a/baselines/packages/mimir/test/no-useless-assertion/definite-assignment-strict/definite-assignment.ts
+++ b/baselines/packages/mimir/test/no-useless-assertion/definite-assignment-strict/definite-assignment.ts
@@ -18,9 +18,9 @@ abstract class Foo {
     bar: number | undefined;
     abstract baz!: number;
     'bas': number;
-    ['foobar']!: number;
+    ['foobar']: number;
     ['foobaz']: number | undefined;
-    [key]!: number;
+    [key]: number;
     [key2]: number | undefined;
     uninitialized: number;
 

--- a/baselines/packages/mimir/test/no-useless-assertion/definite-assignment-strict/definite-assignment.ts.lint
+++ b/baselines/packages/mimir/test/no-useless-assertion/definite-assignment-strict/definite-assignment.ts.lint
@@ -23,9 +23,11 @@ abstract class Foo {
     'bas'!: number;
          ~          [error no-useless-assertion: This assertion is unnecessary as it has no effect on this declaration.]
     ['foobar']!: number;
+              ~          [error no-useless-assertion: This assertion is unnecessary as it has no effect on this declaration.]
     ['foobaz']!: number | undefined;
               ~                      [error no-useless-assertion: This assertion is unnecessary as it has no effect on this declaration.]
     [key]!: number;
+         ~          [error no-useless-assertion: This assertion is unnecessary as it has no effect on this declaration.]
     [key2]!: number | undefined;
           ~                      [error no-useless-assertion: This assertion is unnecessary as it has no effect on this declaration.]
     uninitialized: number;

--- a/packages/mimir/src/rules/no-useless-assertion.ts
+++ b/packages/mimir/src/rules/no-useless-assertion.ts
@@ -67,7 +67,7 @@ export class Rule extends TypedRule {
         if (node.exclamationToken !== undefined &&
             node.initializer === undefined &&
             !hasModifier(node.modifiers, ts.SyntaxKind.AbstractKeyword) && (
-                node.name.kind === ts.SyntaxKind.StringLiteral || // properties with string key are not checked
+                node.name.kind !== ts.SyntaxKind.Identifier || // properties with string or computed name are not checked
                 !isStrictPropertyInitializationEnabled(this.program.getCompilerOptions()) || // strictPropertyInitialization must be enabled
                 getNullableFlags(this.checker.getTypeAtLocation(node), true) & ts.TypeFlags.Undefined // type does not allow undefined
             ))


### PR DESCRIPTION
#### Checklist

- [ ] Fixes: #
- [x] Added or updated tests / baselines
- [ ] Documentation update

#### Overview of change 
The compiler only checks properties whose names are identifiers.