### PR TITLE
test: don't include remaining failures in fix baseline

### DIFF
--- a/baselines/packages/disir/test/no-barrel-import/project/test.ts
+++ b/baselines/packages/disir/test/no-barrel-import/project/test.ts
@@ -7,5 +7,4 @@ import {foo} from './subdir';
 import {bar} from './subdir/index';
 
 export * from '.';
-              ~~~  [error local/no-barrel-import: Import directly from the module containing the declaration instead of the barrel.]
 export * from '@fimbul/wotan';

--- a/baselines/packages/disir/test/no-import-self/project/test.ts
+++ b/baselines/packages/disir/test/no-import-self/project/test.ts
@@ -3,9 +3,6 @@ import { bar as renamedBar } from './other';
 import { getPackageName } from '../../src/util';
 import {baz} from './index';
 import * as ns from '@fimbul/disir';
-                    ~~~~~~~~~~~~~~~  [error local/no-import-self: Import directly from the module containing the declaration instead of '@fimbul/disir'.]
 import '@fimbul/disir';
-       ~~~~~~~~~~~~~~~  [error local/no-import-self: Import directly from the module containing the declaration instead of '@fimbul/disir'.]
 
 export * from '@fimbul/disir';
-              ~~~~~~~~~~~~~~~  [error local/no-import-self: Import directly from the module containing the declaration instead of '@fimbul/disir'.]

--- a/baselines/packages/mimir/test/no-useless-initializer/project/test.ts
+++ b/baselines/packages/mimir/test/no-useless-initializer/project/test.ts
@@ -57,11 +57,9 @@ declare function get<T>(): T;
     let {['prop']: noDefault} = obj;
     let {prop} = obj;
     let {foo = 'oof'} = get<{foo: 'foo'}>();
-               ~~~~~                         [error no-useless-initializer: Unnecessary default value as this property is never 'undefined'.]
     let {bar = 'bar'} = get<{bar?: 'bar'}>();
     let {baz = 'baz'} = get<{baz: 'baz'} | {baz: undefined}>();
     let {bas = 'bas'} = get<{bas: 'bas'} | {bas: 'foobas'}>();
-               ~~~~~                                           [error no-useless-initializer: Unnecessary default value as this property is never 'undefined'.]
     let {something = 'something'} = get<{[key: string]: string}>();
     let {any = 'any'} = get<{any: any}>();
     let {'prop': renamed} = obj;

--- a/baselines/packages/mimir/test/no-useless-spread/default/test.ts
+++ b/baselines/packages/mimir/test/no-useless-spread/default/test.ts
@@ -7,19 +7,15 @@ console.log('a', 'b', 1, 'c', ...arr, 'd');
 let obj = {
   foo: 1,
   ...{ bar: 2, ...someObj },
-  ~~~~~~~~~~~~~~~~~~~~~~~~~  [error no-useless-spread: Using the spread operator here is not necessary.]
   baz: 3,
   ...someOtherObject || { bas: 4 }
 };
 
 ({foo, .../* comment */{bar, ...rest}} = obj);
-       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~          [error no-useless-spread: Using the spread operator here is not necessary.]
 
 obj = {
     ... // comment
-    ~~~~~~~~~~~~~~
     {...obj}
-~~~~~~~~~~~~ [error no-useless-spread: Using the spread operator here is not necessary.]
 };
 
 console.log();
@@ -35,7 +31,6 @@ let a = [...[,],];
 
 // ({foo: 'foo',});
    ({...{foo: 'foo',},});
-     ~~~~~~~~~~~~~~~~     [error no-useless-spread: Using the spread operator here is not necessary.]
 
 // let a = [];
    let a = [];
@@ -62,8 +57,6 @@ const named = 'bar';
 // don't fix object spread because of possible duplicate key errors
 let myObj = {
     ...{foo: 1},
-    ~~~~~~~~~~~  [error no-useless-spread: Using the spread operator here is not necessary.]
     bar: 1,
     ...{foo: 2, [named]: 2},
-    ~~~~~~~~~~~~~~~~~~~~~~~  [error no-useless-spread: Using the spread operator here is not necessary.]
 };

--- a/baselines/packages/mimir/test/prefer-const/any/module.ts
+++ b/baselines/packages/mimir/test/prefer-const/any/module.ts
@@ -12,7 +12,6 @@ try {
 } catch (e) {}
 
 var ns = {}, notMerged = '';
-             ~~~~~~~~~       [error prefer-const: Variable 'notMerged' is never reassigned. Prefer 'const' instead of 'var'.]
 namespace ns {}
 
 const ns2 = {};
@@ -53,24 +52,18 @@ typeof foobar;
 var foobar = 0;
 
 var {[v1]: v2, v1} = {v1: 0};
-           ~~                 [error prefer-const: Variable 'v2' is never reassigned. Prefer 'const' instead of 'var'.]
 var [v3] = [v3];
 var {foo: {} = v4, v4} = {v4: v2}, v5 = 0;
-                                   ~~      [error prefer-const: Variable 'v5' is never reassigned. Prefer 'const' instead of 'var'.]
 
 function test(a: string, {length}: any[]) {
     var a = '', d = 0, {p1 = p1, foo: [{p3, p4, p5, ...p6} = p3, ...p2] = [p2, p5] } = {p4} as any;
-                ~                                                                                   [error prefer-const: Variable 'd' is never reassigned. Prefer 'const' instead of 'var'.]
-                                                       ~~                                           [error prefer-const: Variable 'p6' is never reassigned. Prefer 'const' instead of 'var'.]
     var b = 0, c = 0;
-               ~      [error prefer-const: Variable 'c' is never reassigned. Prefer 'const' instead of 'var'.]
     var b: number;
 }
 
 for (let len = 10, i = 0; i < len; ++i);
 for (const len = 10, i = 0; i < len;);
 for (let [key, value] of new Map()) {
-               ~~~~~                  [error prefer-const: Variable 'value' is never reassigned. Prefer 'const' instead of 'let'.]
     key = null!;
 }
 for (const key in {}) {}

--- a/baselines/packages/mimir/test/prefer-const/default/module.ts
+++ b/baselines/packages/mimir/test/prefer-const/default/module.ts
@@ -12,7 +12,6 @@ try {
 } catch (e) {}
 
 var ns = {}, notMerged = '';
-             ~~~~~~~~~       [error prefer-const: Variable 'notMerged' is never reassigned. Prefer 'const' instead of 'var'.]
 namespace ns {}
 
 const ns2 = {};
@@ -55,13 +54,10 @@ var foobar = 0;
 var {[v1]: v2, v1} = {v1: 0};
 var [v3] = [v3];
 var {foo: {} = v4, v4} = {v4: v2}, v5 = 0;
-                                   ~~      [error prefer-const: Variable 'v5' is never reassigned. Prefer 'const' instead of 'var'.]
 
 function test(a: string, {length}: any[]) {
     var a = '', d = 0, {p1 = p1, foo: [{p3, p4, p5, ...p6} = p3, ...p2] = [p2, p5] } = {p4} as any;
-                ~                                                                                   [error prefer-const: Variable 'd' is never reassigned. Prefer 'const' instead of 'var'.]
     var b = 0, c = 0;
-               ~      [error prefer-const: Variable 'c' is never reassigned. Prefer 'const' instead of 'var'.]
     var b: number;
 }
 

--- a/baselines/packages/ve/test/default/bye.vue
+++ b/baselines/packages/ve/test/default/bye.vue
@@ -19,7 +19,6 @@ export default Vue.extend({
             let v = null;
             await p;
             v;
-            ~~ [error no-unused-expression: This expression is unused. Did you mean to assign a value or call a function?]
             await foo();
             await Promise.resolve();
         }

--- a/baselines/packages/ve/test/default/foo.ts
+++ b/baselines/packages/ve/test/default/foo.ts
@@ -1,15 +1,12 @@
 import {foo} from './jsx';
 (async function() {
     1;
-    ~~ [error no-unused-expression: This expression is unused. Did you mean to assign a value or call a function?]
     // JSDoc type annotations only work in JavaScript files
     /** @type {PromiseLike<string>} */
     let p = null;
     let v = null;
     p;
-    ~~ [error no-unused-expression: This expression is unused. Did you mean to assign a value or call a function?]
     v;
-    ~~ [error no-unused-expression: This expression is unused. Did you mean to assign a value or call a function?]
     await foo();
     await Promise.resolve();
 })();

--- a/baselines/packages/ve/test/default/hello.vue
+++ b/baselines/packages/ve/test/default/hello.vue
@@ -18,9 +18,7 @@ export default Vue.extend({
             let p = null;
             let v = null;
             p;
-            ~~ [error no-unused-expression: This expression is unused. Did you mean to assign a value or call a function?]
             v;
-            ~~ [error no-unused-expression: This expression is unused. Did you mean to assign a value or call a function?]
             await foo();
             await Promise.resolve();
         }

--- a/baselines/packages/ve/test/default/jsx.tsx
+++ b/baselines/packages/ve/test/default/jsx.tsx
@@ -1,15 +1,11 @@
 <script lang="js"></script>
-~~~~~~~~~~~~~~~~~~~~~~~~~~~ [error no-unused-expression: This expression is unused. Did you mean to assign a value or call a function?]
 export async function foo() {
     1;
-    ~~ [error no-unused-expression: This expression is unused. Did you mean to assign a value or call a function?]
     // JSDoc type annotations only work in JavaScript files
     /** @type {PromiseLike<string>} */
     let p = null;
     let v = null;
     p;
-    ~~ [error no-unused-expression: This expression is unused. Did you mean to assign a value or call a function?]
     v;
-    ~~ [error no-unused-expression: This expression is unused. Did you mean to assign a value or call a function?]
     await Promise.resolve();
 }

--- a/baselines/packages/wotan/test/fix/five/test.ts
+++ b/baselines/packages/wotan/test/fix/five/test.ts
@@ -1,2 +1,1 @@
 fg;
-~   [error local/delete: remove this character]

--- a/baselines/packages/wotan/test/fix/one/test.ts
+++ b/baselines/packages/wotan/test/fix/one/test.ts
@@ -1,2 +1,1 @@
 bcdefg;
-~       [error local/delete: remove this character]

--- a/baselines/packages/wotan/test/project/fix/default/test.ts
+++ b/baselines/packages/wotan/test/project/fix/default/test.ts
@@ -1,3 +1,2 @@
 import {bar as fn} from './other';
 fn();
-~~~~  [error no-unstable-api-use: CallSignature '(): void' is deprecated: bar ]

--- a/baselines/packages/wotan/test/project/fix/default/test.ts.lint
+++ b/baselines/packages/wotan/test/project/fix/default/test.ts.lint
@@ -1,6 +1,5 @@
 import {foo as fn} from './other';
         ~~~                        [error local/foo: 'foo' is not allowed.]
-foo: bar: fn();
-~~~             [error no-unused-label: Unused label 'foo'.]
-     ~~~        [error no-unused-label: Unused label 'bar'.]
-          ~~~~  [error no-unstable-api-use: CallSignature '(): void' is deprecated: foo ]
+foo: bar: <string>fn();
+~~~                     [error no-unused-label: Unused label 'foo'.]
+     ~~~                [error no-unused-label: Unused label 'bar'.]

--- a/packages/wotan/src/commands/test.ts
+++ b/packages/wotan/src/commands/test.ts
@@ -59,7 +59,7 @@ class TestCommandRunner extends AbstractCommandRunner {
                 const relative = path.relative(root, file);
                 if (relative.startsWith('..' + path.sep))
                     throw new ConfigurationError(`Testing file '${file}' outside of '${root}'.`);
-                const actual = createBaseline(summary);
+                const actual = kind === BaselineKind.Fix ? summary.content : createBaseline(summary);
                 const baselineFile = `${path.resolve(baselineDir, relative)}${kind === BaselineKind.Lint ? '.lint' : ''}`;
                 const end = (pass: boolean, text: string, baselineDiff?: string) => {
                     this.logger.log(`  ${chalk.grey.dim(path.relative(basedir, baselineFile))} ${chalk[pass ? 'green' : 'red'](text)}`);

--- a/packages/wotan/test/project/fix/.wotanrc.yaml
+++ b/packages/wotan/test/project/fix/.wotanrc.yaml
@@ -1,6 +1,6 @@
 rulesDirectories:
   local: "."
 rules:
-  no-unstable-api-use: error
+  no-useless-assertion: error
   local/foo: error
   no-unused-label: error

--- a/packages/wotan/test/project/fix/other.ts
+++ b/packages/wotan/test/project/fix/other.ts
@@ -1,4 +1,6 @@
-/** @deprecated bar */
-export function bar() {}
-/** @deprecated foo */
-export function foo() {}
+export function bar(): string {
+    return 'bar';
+}
+export function foo(): string | number{
+    return 'foo';
+}

--- a/packages/wotan/test/project/fix/test.ts
+++ b/packages/wotan/test/project/fix/test.ts
@@ -1,2 +1,2 @@
 import {foo as fn} from './other';
-foo: bar: fn();
+foo: bar: <string>fn();


### PR DESCRIPTION
#### Checklist

- [x] Part of #205 
- [x] Added or updated tests / baselines
- [ ] Documentation update

#### Overview of change 
The error markup in fix baselines are too distracting and interfere with the syntax highlighting of the source code.