### PR TITLE
add parens in autofixer if necessary

### DIFF
--- a/baselines/packages/mimir/test/await-only-promise/default/test.ts.fix
+++ b/baselines/packages/mimir/test/await-only-promise/default/test.ts.fix
@@ -34,6 +34,7 @@ async function test<T extends Promise<string>, U extends T | undefined>(p: T, p2
     get<{[key: string]: (v: string) => void}>(); // no implicit `then` property
     get<number | boolean>();
     /** await */ get<number>();
+    ({prop: 1});
 }
 
 declare function hasThen(v: {}): v is {then: {}};

--- a/baselines/packages/mimir/test/await-only-promise/default/test.ts.lint
+++ b/baselines/packages/mimir/test/await-only-promise/default/test.ts.lint
@@ -44,6 +44,8 @@ async function test<T extends Promise<string>, U extends T | undefined>(p: T, p2
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  [error await-only-promise: Unnecessary 'await' of a non-Promise value.]
     /** await */ await get<number>();
                  ~~~~~~~~~~~~~~~~~~~  [error await-only-promise: Unnecessary 'await' of a non-Promise value.]
+    await {prop: 1};
+    ~~~~~~~~~~~~~~~  [error await-only-promise: Unnecessary 'await' of a non-Promise value.]
 }
 
 declare function hasThen(v: {}): v is {then: {}};

--- a/baselines/packages/mimir/test/await-only-promise/pre260/test.ts.lint
+++ b/baselines/packages/mimir/test/await-only-promise/pre260/test.ts.lint
@@ -45,6 +45,8 @@ async function test<T extends Promise<string>, U extends T | undefined>(p: T, p2
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  [error await-only-promise: Unnecessary 'await' of a non-Promise value.]
     /** await */ await get<number>();
                  ~~~~~~~~~~~~~~~~~~~  [error await-only-promise: Unnecessary 'await' of a non-Promise value.]
+    await {prop: 1};
+    ~~~~~~~~~~~~~~~  [error await-only-promise: Unnecessary 'await' of a non-Promise value.]
 }
 
 declare function hasThen(v: {}): v is {then: {}};

--- a/baselines/packages/mimir/test/no-return-await/default/test.ts.fix
+++ b/baselines/packages/mimir/test/no-return-await/default/test.ts.fix
@@ -92,7 +92,12 @@ try {
 }
 
 async () => ({foo: 1});
+async () => ({foo: 1}['foo']);
 
 async function parensWhenNecessary() {
+    if (Boolean())
+        return {prop: 1}.prop;
+    if (!Boolean())
+        return function() {return 1;}();
     return {foo: 1};
 }

--- a/baselines/packages/mimir/test/no-return-await/default/test.ts.lint
+++ b/baselines/packages/mimir/test/no-return-await/default/test.ts.lint
@@ -110,8 +110,16 @@ try {
 
 async () => await {foo: 1};
             ~~~~~           [error no-return-await: Awaiting the returned value is redundant as it is wrapped in a Promise anyway.]
+async () => await {foo: 1}['foo'];
+            ~~~~~                  [error no-return-await: Awaiting the returned value is redundant as it is wrapped in a Promise anyway.]
 
 async function parensWhenNecessary() {
+    if (Boolean())
+        return await {prop: 1}.prop;
+               ~~~~~                 [error no-return-await: Awaiting the returned value is redundant as it is wrapped in a Promise anyway.]
+    if (!Boolean())
+        return await function() {return 1;}();
+               ~~~~~                           [error no-return-await: Awaiting the returned value is redundant as it is wrapped in a Promise anyway.]
     return await {foo: 1};
            ~~~~~           [error no-return-await: Awaiting the returned value is redundant as it is wrapped in a Promise anyway.]
 }

--- a/baselines/packages/mimir/test/no-useless-assertion/270-strict/non-null.ts.fix
+++ b/baselines/packages/mimir/test/no-useless-assertion/270-strict/non-null.ts.fix
@@ -63,6 +63,9 @@ let l: string | null;
 let m: any;
 m;
 
+let n: string | void = null as any;
+n;
+
 foobar;
 
 declare let possiblyNull: string | null;
@@ -160,3 +163,28 @@ function fn4<T extends {} | undefined, U extends {}>(param1: T, param2: U) {
     takeObject(v);
     function takeObject(o: {}) {}
 }
+
+let outer: number;
+(function useBeforeDeclare() {
+    outer!;
+    let inner: number;
+    inner!;
+    (() => outer! + inner! + function() {
+        return outer! + inner!;
+    }())();
+    (async function() {
+        outer;
+        inner;
+    })();
+    (function*(param) {
+        yield;
+        outer;
+        inner;
+    })(() => outer);
+    function nested() {
+        outer;
+        inner;
+        (() => outer + inner)();
+    }
+    (() => inner);
+})();

--- a/baselines/packages/mimir/test/no-useless-assertion/270-strict/non-null.ts.lint
+++ b/baselines/packages/mimir/test/no-useless-assertion/270-strict/non-null.ts.lint
@@ -79,6 +79,10 @@ let m: any;
 m!;
  ~  [error no-useless-assertion: This assertion is unnecesary as it doesn't change the type of the expression.]
 
+let n: string | void = null as any;
+n!;
+ ~  [error no-useless-assertion: This assertion is unnecesary as it doesn't change the type of the expression.]
+
 foobar!;
       ~  [error no-useless-assertion: This assertion is unnecesary as it doesn't change the type of the expression.]
 
@@ -200,3 +204,38 @@ function fn4<T extends {} | undefined, U extends {}>(param1: T, param2: U) {
                 ~   [error no-useless-assertion: This assertion is unnecesary as it doesn't change the type of the expression.]
     function takeObject(o: {}) {}
 }
+
+let outer: number;
+(function useBeforeDeclare() {
+    outer!;
+    let inner: number;
+    inner!;
+    (() => outer! + inner! + function() {
+        return outer! + inner!;
+    }())();
+    (async function() {
+        outer!;
+             ~  [error no-useless-assertion: This assertion is unnecesary as it doesn't change the type of the expression.]
+        inner!;
+             ~  [error no-useless-assertion: This assertion is unnecesary as it doesn't change the type of the expression.]
+    })();
+    (function*(param) {
+        yield;
+        outer!;
+             ~  [error no-useless-assertion: This assertion is unnecesary as it doesn't change the type of the expression.]
+        inner!;
+             ~  [error no-useless-assertion: This assertion is unnecesary as it doesn't change the type of the expression.]
+    })(() => outer!);
+                  ~   [error no-useless-assertion: This assertion is unnecesary as it doesn't change the type of the expression.]
+    function nested() {
+        outer!;
+             ~  [error no-useless-assertion: This assertion is unnecesary as it doesn't change the type of the expression.]
+        inner!;
+             ~  [error no-useless-assertion: This assertion is unnecesary as it doesn't change the type of the expression.]
+        (() => outer! + inner!)();
+                    ~              [error no-useless-assertion: This assertion is unnecesary as it doesn't change the type of the expression.]
+                             ~     [error no-useless-assertion: This assertion is unnecesary as it doesn't change the type of the expression.]
+    }
+    (() => inner!);
+                ~   [error no-useless-assertion: This assertion is unnecesary as it doesn't change the type of the expression.]
+})();

--- a/baselines/packages/mimir/test/no-useless-assertion/270-strict/type-assertion.ts.fix
+++ b/baselines/packages/mimir/test/no-useless-assertion/270-strict/type-assertion.ts.fix
@@ -1,5 +1,3 @@
-export {};
-
 <1>1;
 <number>1;
 (1 + 1);
@@ -105,3 +103,11 @@ namespace B {
 
 declare let myObj: A.MyClass;
 <B.MyClass>myObj;
+
+({prop: 1}.prop);
+(class {static prop: number}.prop);
+(function() { return 1; }());
+
+export default (class{static prop: number}.prop);
+export default {prop: 1}.prop;
+export = class{static prop: number}.prop;

--- a/baselines/packages/mimir/test/no-useless-assertion/270-strict/type-assertion.ts.lint
+++ b/baselines/packages/mimir/test/no-useless-assertion/270-strict/type-assertion.ts.lint
@@ -1,5 +1,3 @@
-export {};
-
 <1>1;
 <number>1;
 <number>(1 + 1);
@@ -129,3 +127,17 @@ namespace B {
 
 declare let myObj: A.MyClass;
 <B.MyClass>myObj;
+
+<number>{prop: 1}.prop;
+~~~~~~~~                [error no-useless-assertion: This assertion is unnecesary as it doesn't change the type of the expression.]
+<number>class {static prop: number}.prop;
+~~~~~~~~                                  [error no-useless-assertion: This assertion is unnecesary as it doesn't change the type of the expression.]
+<number>function() { return 1; }();
+~~~~~~~~                            [error no-useless-assertion: This assertion is unnecesary as it doesn't change the type of the expression.]
+
+export default <number>class{static prop: number}.prop;
+               ~~~~~~~~                                 [error no-useless-assertion: This assertion is unnecesary as it doesn't change the type of the expression.]
+export default <number>{prop: 1}.prop;
+               ~~~~~~~~                [error no-useless-assertion: This assertion is unnecesary as it doesn't change the type of the expression.]
+export = <number>class{static prop: number}.prop;
+         ~~~~~~~~                                 [error no-useless-assertion: This assertion is unnecesary as it doesn't change the type of the expression.]

--- a/baselines/packages/mimir/test/no-useless-assertion/post270-loose/type-assertion.ts.fix
+++ b/baselines/packages/mimir/test/no-useless-assertion/post270-loose/type-assertion.ts.fix
@@ -1,5 +1,3 @@
-export {};
-
 <1>1;
 <number>1;
 (1 + 1);
@@ -105,3 +103,11 @@ namespace B {
 
 declare let myObj: A.MyClass;
 <B.MyClass>myObj;
+
+({prop: 1}.prop);
+(class {static prop: number}.prop);
+(function() { return 1; }());
+
+export default (class{static prop: number}.prop);
+export default {prop: 1}.prop;
+export = class{static prop: number}.prop;

--- a/baselines/packages/mimir/test/no-useless-assertion/post270-loose/type-assertion.ts.lint
+++ b/baselines/packages/mimir/test/no-useless-assertion/post270-loose/type-assertion.ts.lint
@@ -1,5 +1,3 @@
-export {};
-
 <1>1;
 <number>1;
 <number>(1 + 1);
@@ -136,3 +134,17 @@ namespace B {
 
 declare let myObj: A.MyClass;
 <B.MyClass>myObj;
+
+<number>{prop: 1}.prop;
+~~~~~~~~                [error no-useless-assertion: This assertion is unnecesary as it doesn't change the type of the expression.]
+<number>class {static prop: number}.prop;
+~~~~~~~~                                  [error no-useless-assertion: This assertion is unnecesary as it doesn't change the type of the expression.]
+<number>function() { return 1; }();
+~~~~~~~~                            [error no-useless-assertion: This assertion is unnecesary as it doesn't change the type of the expression.]
+
+export default <number>class{static prop: number}.prop;
+               ~~~~~~~~                                 [error no-useless-assertion: This assertion is unnecesary as it doesn't change the type of the expression.]
+export default <number>{prop: 1}.prop;
+               ~~~~~~~~                [error no-useless-assertion: This assertion is unnecesary as it doesn't change the type of the expression.]
+export = <number>class{static prop: number}.prop;
+         ~~~~~~~~                                 [error no-useless-assertion: This assertion is unnecesary as it doesn't change the type of the expression.]

--- a/baselines/packages/mimir/test/no-useless-assertion/post270-strict/type-assertion.ts.fix
+++ b/baselines/packages/mimir/test/no-useless-assertion/post270-strict/type-assertion.ts.fix
@@ -1,5 +1,3 @@
-export {};
-
 <1>1;
 <number>1;
 (1 + 1);
@@ -105,3 +103,11 @@ namespace B {
 
 declare let myObj: A.MyClass;
 <B.MyClass>myObj;
+
+({prop: 1}.prop);
+(class {static prop: number}.prop);
+(function() { return 1; }());
+
+export default (class{static prop: number}.prop);
+export default {prop: 1}.prop;
+export = class{static prop: number}.prop;

--- a/baselines/packages/mimir/test/no-useless-assertion/post270-strict/type-assertion.ts.lint
+++ b/baselines/packages/mimir/test/no-useless-assertion/post270-strict/type-assertion.ts.lint
@@ -1,5 +1,3 @@
-export {};
-
 <1>1;
 <number>1;
 <number>(1 + 1);
@@ -129,3 +127,17 @@ namespace B {
 
 declare let myObj: A.MyClass;
 <B.MyClass>myObj;
+
+<number>{prop: 1}.prop;
+~~~~~~~~                [error no-useless-assertion: This assertion is unnecesary as it doesn't change the type of the expression.]
+<number>class {static prop: number}.prop;
+~~~~~~~~                                  [error no-useless-assertion: This assertion is unnecesary as it doesn't change the type of the expression.]
+<number>function() { return 1; }();
+~~~~~~~~                            [error no-useless-assertion: This assertion is unnecesary as it doesn't change the type of the expression.]
+
+export default <number>class{static prop: number}.prop;
+               ~~~~~~~~                                 [error no-useless-assertion: This assertion is unnecesary as it doesn't change the type of the expression.]
+export default <number>{prop: 1}.prop;
+               ~~~~~~~~                [error no-useless-assertion: This assertion is unnecesary as it doesn't change the type of the expression.]
+export = <number>class{static prop: number}.prop;
+         ~~~~~~~~                                 [error no-useless-assertion: This assertion is unnecesary as it doesn't change the type of the expression.]

--- a/baselines/packages/mimir/test/no-useless-assertion/pre270-loose/type-assertion.ts.fix
+++ b/baselines/packages/mimir/test/no-useless-assertion/pre270-loose/type-assertion.ts.fix
@@ -1,5 +1,3 @@
-export {};
-
 <1>1;
 <number>1;
 (1 + 1);
@@ -105,3 +103,11 @@ namespace B {
 
 declare let myObj: A.MyClass;
 <B.MyClass>myObj;
+
+({prop: 1}.prop);
+(class {static prop: number}.prop);
+(function() { return 1; }());
+
+export default (class{static prop: number}.prop);
+export default {prop: 1}.prop;
+export = class{static prop: number}.prop;

--- a/baselines/packages/mimir/test/no-useless-assertion/pre270-loose/type-assertion.ts.lint
+++ b/baselines/packages/mimir/test/no-useless-assertion/pre270-loose/type-assertion.ts.lint
@@ -1,5 +1,3 @@
-export {};
-
 <1>1;
 <number>1;
 <number>(1 + 1);
@@ -136,3 +134,17 @@ namespace B {
 
 declare let myObj: A.MyClass;
 <B.MyClass>myObj;
+
+<number>{prop: 1}.prop;
+~~~~~~~~                [error no-useless-assertion: This assertion is unnecesary as it doesn't change the type of the expression.]
+<number>class {static prop: number}.prop;
+~~~~~~~~                                  [error no-useless-assertion: This assertion is unnecesary as it doesn't change the type of the expression.]
+<number>function() { return 1; }();
+~~~~~~~~                            [error no-useless-assertion: This assertion is unnecesary as it doesn't change the type of the expression.]
+
+export default <number>class{static prop: number}.prop;
+               ~~~~~~~~                                 [error no-useless-assertion: This assertion is unnecesary as it doesn't change the type of the expression.]
+export default <number>{prop: 1}.prop;
+               ~~~~~~~~                [error no-useless-assertion: This assertion is unnecesary as it doesn't change the type of the expression.]
+export = <number>class{static prop: number}.prop;
+         ~~~~~~~~                                 [error no-useless-assertion: This assertion is unnecesary as it doesn't change the type of the expression.]

--- a/baselines/packages/mimir/test/no-useless-assertion/pre270-strict/type-assertion.ts.fix
+++ b/baselines/packages/mimir/test/no-useless-assertion/pre270-strict/type-assertion.ts.fix
@@ -1,5 +1,3 @@
-export {};
-
 <1>1;
 <number>1;
 (1 + 1);
@@ -105,3 +103,11 @@ namespace B {
 
 declare let myObj: A.MyClass;
 <B.MyClass>myObj;
+
+({prop: 1}.prop);
+(class {static prop: number}.prop);
+(function() { return 1; }());
+
+export default (class{static prop: number}.prop);
+export default {prop: 1}.prop;
+export = class{static prop: number}.prop;

--- a/baselines/packages/mimir/test/no-useless-assertion/pre270-strict/type-assertion.ts.lint
+++ b/baselines/packages/mimir/test/no-useless-assertion/pre270-strict/type-assertion.ts.lint
@@ -1,5 +1,3 @@
-export {};
-
 <1>1;
 <number>1;
 <number>(1 + 1);
@@ -129,3 +127,17 @@ namespace B {
 
 declare let myObj: A.MyClass;
 <B.MyClass>myObj;
+
+<number>{prop: 1}.prop;
+~~~~~~~~                [error no-useless-assertion: This assertion is unnecesary as it doesn't change the type of the expression.]
+<number>class {static prop: number}.prop;
+~~~~~~~~                                  [error no-useless-assertion: This assertion is unnecesary as it doesn't change the type of the expression.]
+<number>function() { return 1; }();
+~~~~~~~~                            [error no-useless-assertion: This assertion is unnecesary as it doesn't change the type of the expression.]
+
+export default <number>class{static prop: number}.prop;
+               ~~~~~~~~                                 [error no-useless-assertion: This assertion is unnecesary as it doesn't change the type of the expression.]
+export default <number>{prop: 1}.prop;
+               ~~~~~~~~                [error no-useless-assertion: This assertion is unnecesary as it doesn't change the type of the expression.]
+export = <number>class{static prop: number}.prop;
+         ~~~~~~~~                                 [error no-useless-assertion: This assertion is unnecesary as it doesn't change the type of the expression.]

--- a/baselines/packages/mimir/test/prefer-object-spread/default/test.ts.fix
+++ b/baselines/packages/mimir/test/prefer-object-spread/default/test.ts.fix
@@ -62,3 +62,10 @@ obj = {prop: 1,prop: 2,...obj,}
 obj = {};
 
 obj = {...Boolean() && {prop: 1}, ...Boolean() ? {prop2: 1} : {prop3: 1}};
+
+({})! as {} + '';
+({method() {return [0];}}).method()[0]++ === 1 ? 'foo' : 'bar';
+({}).toString();
+
+console.log({});
+obj.toString(), {};

--- a/baselines/packages/mimir/test/prefer-object-spread/default/test.ts.lint
+++ b/baselines/packages/mimir/test/prefer-object-spread/default/test.ts.lint
@@ -86,3 +86,15 @@ obj = Object.assign({});
 
 obj = Object.assign({}, Boolean() && {prop: 1}, Boolean() ? {prop2: 1} : {prop3: 1});
       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  [error prefer-object-spread: Prefer object spread over 'Object.assign'.]
+
+Object.assign({})! as {} + '';
+~~~~~~~~~~~~~~~~~              [error prefer-object-spread: No need for 'Object.assign', use the object directly.]
+Object.assign({method() {return [0];}}).method()[0]++ === 1 ? 'foo' : 'bar';
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~                                      [error prefer-object-spread: No need for 'Object.assign', use the object directly.]
+(Object.assign({})).toString();
+ ~~~~~~~~~~~~~~~~~              [error prefer-object-spread: No need for 'Object.assign', use the object directly.]
+
+console.log(Object.assign({}));
+            ~~~~~~~~~~~~~~~~~   [error prefer-object-spread: No need for 'Object.assign', use the object directly.]
+obj.toString(), Object.assign({});
+                ~~~~~~~~~~~~~~~~~  [error prefer-object-spread: No need for 'Object.assign', use the object directly.]

--- a/packages/mimir/src/rules/no-return-await.ts
+++ b/packages/mimir/src/rules/no-return-await.ts
@@ -1,6 +1,7 @@
 import { AbstractRule, Replacement, excludeDeclarationFiles } from '@fimbul/ymir';
 import * as ts from 'typescript';
-import { isFunctionScopeBoundary, isTryStatement, WrappedAst, getWrappedNodeAtPosition, isAwaitExpression, isArrowFunction } from 'tsutils';
+import { isFunctionScopeBoundary, isTryStatement, WrappedAst, getWrappedNodeAtPosition, isAwaitExpression } from 'tsutils';
+import { expressionNeedsParensWhenReplacingNode } from '../utils';
 
 const FAIL_MESSAGE = 'Awaiting the returned value is redundant as it is wrapped in a Promise anyway.';
 
@@ -15,10 +16,10 @@ export class Rule extends AbstractRule {
                 const keywordStart = node.expression.pos - 'await'.length;
                 const replacements = [Replacement.delete(keywordStart, node.expression.getStart(this.sourceFile))];
 
-                if (isArrowFunction(node.parent!) && node.expression.kind === ts.SyntaxKind.ObjectLiteralExpression)
+                if (expressionNeedsParensWhenReplacingNode(node.expression, node))
                     replacements.push(
-                        Replacement.append(node.expression.getStart(this.sourceFile), '('),
-                        Replacement.append(node.expression.getEnd(), ')'),
+                        Replacement.append(keywordStart, '('),
+                        Replacement.append(node.expression.end, ')'),
                     );
 
                 this.addFailure(

--- a/packages/mimir/src/rules/prefer-object-spread.ts
+++ b/packages/mimir/src/rules/prefer-object-spread.ts
@@ -10,6 +10,7 @@ import {
     unionTypeParts,
     isFalsyType,
 } from 'tsutils';
+import { objectLiteralNeedsParens } from '../utils';
 
 @excludeDeclarationFiles
 export class Rule extends TypedRule {
@@ -65,7 +66,7 @@ export class Rule extends TypedRule {
 
 function createFix(node: ts.CallExpression, sourceFile: ts.SourceFile) {
     const args = node.arguments;
-    const objectNeedsParens = node.parent!.kind === ts.SyntaxKind.ArrowFunction || node.parent!.kind === ts.SyntaxKind.ExpressionStatement;
+    const objectNeedsParens = objectLiteralNeedsParens(node);
     const fix = [
         Replacement.replace(node.getStart(sourceFile), args[0].getStart(sourceFile), `${objectNeedsParens ? '(' : ''}{`),
         Replacement.replace(node.end - 1, node.end, `}${objectNeedsParens ? ')' : ''}`),

--- a/packages/mimir/test/await-only-promise/test.ts
+++ b/packages/mimir/test/await-only-promise/test.ts
@@ -34,6 +34,7 @@ async function test<T extends Promise<string>, U extends T | undefined>(p: T, p2
     await get<{[key: string]: (v: string) => void}>(); // no implicit `then` property
     await get<number | boolean>();
     /** await */ await get<number>();
+    await {prop: 1};
 }
 
 declare function hasThen(v: {}): v is {then: {}};

--- a/packages/mimir/test/no-return-await/test.ts
+++ b/packages/mimir/test/no-return-await/test.ts
@@ -92,7 +92,12 @@ try {
 }
 
 async () => await {foo: 1};
+async () => await {foo: 1}['foo'];
 
 async function parensWhenNecessary() {
+    if (Boolean())
+        return await {prop: 1}.prop;
+    if (!Boolean())
+        return await function() {return 1;}();
     return await {foo: 1};
 }

--- a/packages/mimir/test/no-useless-assertion/type-assertion.ts
+++ b/packages/mimir/test/no-useless-assertion/type-assertion.ts
@@ -1,5 +1,3 @@
-export {};
-
 <1>1;
 <number>1;
 <number>(1 + 1);
@@ -105,3 +103,11 @@ namespace B {
 
 declare let myObj: A.MyClass;
 <B.MyClass>myObj;
+
+<number>{prop: 1}.prop;
+<number>class {static prop: number}.prop;
+<number>function() { return 1; }();
+
+export default <number>class{static prop: number}.prop;
+export default <number>{prop: 1}.prop;
+export = <number>class{static prop: number}.prop;

--- a/packages/mimir/test/prefer-object-spread/test.ts
+++ b/packages/mimir/test/prefer-object-spread/test.ts
@@ -65,3 +65,10 @@ obj = Object.assign({prop: 1}, {}, {}, {prop: 2}, {}, obj, {},)
 obj = Object.assign({});
 
 obj = Object.assign({}, Boolean() && {prop: 1}, Boolean() ? {prop2: 1} : {prop3: 1});
+
+Object.assign({})! as {} + '';
+Object.assign({method() {return [0];}}).method()[0]++ === 1 ? 'foo' : 'bar';
+(Object.assign({})).toString();
+
+console.log(Object.assign({}));
+obj.toString(), Object.assign({});


### PR DESCRIPTION
#### Checklist

- [x] Fixes: #202, Fixes: #250
- [x] Added or updated tests / baselines
- [ ] Documentation update

#### Overview of change 
Also checks nested expressions that would cause parsing ambiguity. Prevent class and function expressions from being parsed as declaration statement.

* await-only-promise, fixes: #202
* no-return-await
* no-useless-assertion, fixes: #250
* prefer-object-spread