### PR TITLE
Fix typo on install with yarn

### DIFF
--- a/packages/wotan/README.md
+++ b/packages/wotan/README.md
@@ -19,7 +19,7 @@ Install Wotan as a local dependency:
 ```sh
 npm install --save-dev @fimbul/wotan
 # or
-yarn add -D @fimbult/wotan
+yarn add -D @fimbul/wotan
 ```
 
 Add a `.wotanrc.yaml` file to the root of your project with the following content:


### PR DESCRIPTION
The url on the install of wotan with yarn wasnt valid.
There was an extra "t".

#### Checklist

- [ ] Fixes: #
- [ ] Added or updated tests / baselines
- [ ] Documentation update

#### Overview of change 
