### PR TITLE
type-assertion: handle binary expressions with classic type assertion

### DIFF
--- a/baselines/packages/mimir/test/type-assertion/classic/test.ts.fix
+++ b/baselines/packages/mimir/test/type-assertion/classic/test.ts.fix
@@ -33,6 +33,15 @@ void (<T>foo);
 foo & <T>bar;
 foo & <T>bar;
 
+(<number>1) ** 2;
+(<number>1) ** 2;
+
+<number>(1 ** 2 + 1);
+<number>(1 ** 2 + 1);
+
+1 & <number>2;
+1 & <number>2;
+
 foo & <T>bar | baz;
 foo & (<T>bar) | baz;
 

--- a/baselines/packages/mimir/test/type-assertion/classic/test.ts.fix
+++ b/baselines/packages/mimir/test/type-assertion/classic/test.ts.fix
@@ -39,9 +39,6 @@ foo & <T>bar;
 <number>(1 ** 2 + 1);
 <number>(1 ** 2 + 1);
 
-1 & <number>2;
-1 & <number>2;
-
 foo & <T>bar | baz;
 foo & (<T>bar) | baz;
 

--- a/baselines/packages/mimir/test/type-assertion/classic/test.ts.lint
+++ b/baselines/packages/mimir/test/type-assertion/classic/test.ts.lint
@@ -43,6 +43,18 @@ foo & <T>bar;
 foo & bar as T;
           ~~~~  [error type-assertion: Use the classic type assertion style '<T>obj' instead.]
 
+1 as number ** 2;
+  ~~~~~~~~~       [error type-assertion: Use the classic type assertion style '<T>obj' instead.]
+(<number>1) ** 2;
+
+1 ** 2 + 1 as number;
+           ~~~~~~~~~  [error type-assertion: Use the classic type assertion style '<T>obj' instead.]
+<number>(1 ** 2 + 1);
+
+1 & 2 as number;
+      ~~~~~~~~~  [error type-assertion: Use the classic type assertion style '<T>obj' instead.]
+1 & <number>2;
+
 foo & <T>bar | baz;
 foo & (bar as T) | baz;
            ~~~~         [error type-assertion: Use the classic type assertion style '<T>obj' instead.]

--- a/baselines/packages/mimir/test/type-assertion/classic/test.ts.lint
+++ b/baselines/packages/mimir/test/type-assertion/classic/test.ts.lint
@@ -51,10 +51,6 @@ foo & bar as T;
            ~~~~~~~~~  [error type-assertion: Use the classic type assertion style '<T>obj' instead.]
 <number>(1 ** 2 + 1);
 
-1 & 2 as number;
-      ~~~~~~~~~  [error type-assertion: Use the classic type assertion style '<T>obj' instead.]
-1 & <number>2;
-
 foo & <T>bar | baz;
 foo & (bar as T) | baz;
            ~~~~         [error type-assertion: Use the classic type assertion style '<T>obj' instead.]

--- a/baselines/packages/mimir/test/type-assertion/default/test.ts.fix
+++ b/baselines/packages/mimir/test/type-assertion/default/test.ts.fix
@@ -39,9 +39,6 @@ foo & bar as T;
 1 ** 2 + 1 as number;
 (1 ** 2 + 1) as number;
 
-1 & 2 as number;
-1 & 2 as number;
-
 foo & (bar as T) | baz;
 foo & (bar as T) | baz;
 

--- a/baselines/packages/mimir/test/type-assertion/default/test.ts.fix
+++ b/baselines/packages/mimir/test/type-assertion/default/test.ts.fix
@@ -33,6 +33,15 @@ foo as T && bar;
 foo & bar as T;
 foo & bar as T;
 
+1 as number ** 2;
+(1 as number) ** 2;
+
+1 ** 2 + 1 as number;
+(1 ** 2 + 1) as number;
+
+1 & 2 as number;
+1 & 2 as number;
+
 foo & (bar as T) | baz;
 foo & (bar as T) | baz;
 

--- a/baselines/packages/mimir/test/type-assertion/default/test.ts.lint
+++ b/baselines/packages/mimir/test/type-assertion/default/test.ts.lint
@@ -51,10 +51,6 @@ foo & bar as T;
 <number>(1 ** 2 + 1);
 ~~~~~~~~              [error type-assertion: Use 'obj as T' instead.]
 
-1 & 2 as number;
-1 & <number>2;
-    ~~~~~~~~   [error type-assertion: Use 'obj as T' instead.]
-
 foo & <T>bar | baz;
       ~~~           [error type-assertion: Use 'obj as T' instead.]
 foo & (bar as T) | baz;

--- a/baselines/packages/mimir/test/type-assertion/default/test.ts.lint
+++ b/baselines/packages/mimir/test/type-assertion/default/test.ts.lint
@@ -43,6 +43,18 @@ foo & <T>bar;
       ~~~     [error type-assertion: Use 'obj as T' instead.]
 foo & bar as T;
 
+1 as number ** 2;
+(<number>1) ** 2;
+ ~~~~~~~~         [error type-assertion: Use 'obj as T' instead.]
+
+1 ** 2 + 1 as number;
+<number>(1 ** 2 + 1);
+~~~~~~~~              [error type-assertion: Use 'obj as T' instead.]
+
+1 & 2 as number;
+1 & <number>2;
+    ~~~~~~~~   [error type-assertion: Use 'obj as T' instead.]
+
 foo & <T>bar | baz;
       ~~~           [error type-assertion: Use 'obj as T' instead.]
 foo & (bar as T) | baz;

--- a/packages/mimir/test/type-assertion/test.ts
+++ b/packages/mimir/test/type-assertion/test.ts
@@ -33,6 +33,12 @@ foo as T && bar;
 foo & <T>bar;
 foo & bar as T;
 
+1 as number ** 2;
+(<number>1) ** 2;
+
+1 ** 2 + 1 as number;
+<number>(1 ** 2 + 1);
+
 foo & <T>bar | baz;
 foo & (bar as T) | baz;
 


### PR DESCRIPTION
#### Checklist

- [x] Added or updated tests / baselines

#### Overview of change 
* avoid parse error in exponentiation operator: `<T>1 ** 2` is not allowed, use `(<T>1) ** 2` instead
* avoid changing semantics of binary expressions