### PR TITLE
no-useless-initializer: check computed name in binding pattern

### DIFF
--- a/baselines/packages/mimir/test/no-useless-initializer/default/test.ts.fix
+++ b/baselines/packages/mimir/test/no-useless-initializer/default/test.ts.fix
@@ -67,12 +67,12 @@ declare function get<T>(): T;
     let {unknown = 'unknown'} = get<{unknown: unknown}>();
     let {'prop': renamed = 'renamed'} = obj;
     const propName = 'prop';
-    let {[propName]: computed = 'computed'} = obj;
-    const propName2: string | 1 | 2 = null as any;
-    let {[propName2]: computed2 = 'computed'} = get<{[key: string]: string, 1: string, 2: string}>();
+    const {[propName]: computed = null} = obj;
+    const propName2: string = null as any;
+    let {[propName2]: computed2 = ''} = get<{[key: string]: string}>();
     const propName3 = 1;
-    let {[propName3]: computed3 = 'computed'} = get<{1: string, 2: string}>();
-    let {[Symbol.iterator]: iterator = () => get<IterableIterator<number>>()} = [1];
+    const {[propName3]: computed3 = null} = get<{1: string, 2: string}>();
+    const {[Symbol.iterator]: iterator = () => get<IterableIterator<string>>()} = [1];
     let {nested: {prop: nestedProp = 'nestedProp'} = obj} = get<{nested: typeof obj}>();
     let {toString = () => 'foo'} = 1;
 

--- a/baselines/packages/mimir/test/no-useless-initializer/default/test.ts.fix
+++ b/baselines/packages/mimir/test/no-useless-initializer/default/test.ts.fix
@@ -66,7 +66,13 @@ declare function get<T>(): T;
     let {any = 'any'} = get<{any: any}>();
     let {unknown = 'unknown'} = get<{unknown: unknown}>();
     let {'prop': renamed = 'renamed'} = obj;
-    let {[get<'prop'>()]: computed = 'computed'} = obj;
+    const propName = 'prop';
+    let {[propName]: computed = 'computed'} = obj;
+    const propName2: string | 1 | 2 = null as any;
+    let {[propName2]: computed2 = 'computed'} = get<{[key: string]: string, 1: string, 2: string}>();
+    const propName3 = 1;
+    let {[propName3]: computed3 = 'computed'} = get<{1: string, 2: string}>();
+    let {[Symbol.iterator]: iterator = () => get<IterableIterator<number>>()} = [1];
     let {nested: {prop: nestedProp = 'nestedProp'} = obj} = get<{nested: typeof obj}>();
     let {toString = () => 'foo'} = 1;
 

--- a/baselines/packages/mimir/test/no-useless-initializer/default/test.ts.lint
+++ b/baselines/packages/mimir/test/no-useless-initializer/default/test.ts.lint
@@ -75,7 +75,13 @@ declare function get<T>(): T;
     let {any = 'any'} = get<{any: any}>();
     let {unknown = 'unknown'} = get<{unknown: unknown}>();
     let {'prop': renamed = 'renamed'} = obj;
-    let {[get<'prop'>()]: computed = 'computed'} = obj;
+    const propName = 'prop';
+    let {[propName]: computed = 'computed'} = obj;
+    const propName2: string | 1 | 2 = null as any;
+    let {[propName2]: computed2 = 'computed'} = get<{[key: string]: string, 1: string, 2: string}>();
+    const propName3 = 1;
+    let {[propName3]: computed3 = 'computed'} = get<{1: string, 2: string}>();
+    let {[Symbol.iterator]: iterator = () => get<IterableIterator<number>>()} = [1];
     let {nested: {prop: nestedProp = 'nestedProp'} = obj} = get<{nested: typeof obj}>();
     let {toString = () => 'foo'} = 1;
 

--- a/baselines/packages/mimir/test/no-useless-initializer/default/test.ts.lint
+++ b/baselines/packages/mimir/test/no-useless-initializer/default/test.ts.lint
@@ -76,12 +76,12 @@ declare function get<T>(): T;
     let {unknown = 'unknown'} = get<{unknown: unknown}>();
     let {'prop': renamed = 'renamed'} = obj;
     const propName = 'prop';
-    let {[propName]: computed = 'computed'} = obj;
-    const propName2: string | 1 | 2 = null as any;
-    let {[propName2]: computed2 = 'computed'} = get<{[key: string]: string, 1: string, 2: string}>();
+    const {[propName]: computed = null} = obj;
+    const propName2: string = null as any;
+    let {[propName2]: computed2 = ''} = get<{[key: string]: string}>();
     const propName3 = 1;
-    let {[propName3]: computed3 = 'computed'} = get<{1: string, 2: string}>();
-    let {[Symbol.iterator]: iterator = () => get<IterableIterator<number>>()} = [1];
+    const {[propName3]: computed3 = null} = get<{1: string, 2: string}>();
+    const {[Symbol.iterator]: iterator = () => get<IterableIterator<string>>()} = [1];
     let {nested: {prop: nestedProp = 'nestedProp'} = obj} = get<{nested: typeof obj}>();
     let {toString = () => 'foo'} = 1;
 

--- a/baselines/packages/mimir/test/no-useless-initializer/project-loose/test.ts.fix
+++ b/baselines/packages/mimir/test/no-useless-initializer/project-loose/test.ts.fix
@@ -67,12 +67,12 @@ declare function get<T>(): T;
     let {unknown = 'unknown'} = get<{unknown: unknown}>();
     let {'prop': renamed = 'renamed'} = obj;
     const propName = 'prop';
-    let {[propName]: computed = 'computed'} = obj;
-    const propName2: string | 1 | 2 = null as any;
-    let {[propName2]: computed2 = 'computed'} = get<{[key: string]: string, 1: string, 2: string}>();
+    const {[propName]: computed = null} = obj;
+    const propName2: string = null as any;
+    let {[propName2]: computed2 = ''} = get<{[key: string]: string}>();
     const propName3 = 1;
-    let {[propName3]: computed3 = 'computed'} = get<{1: string, 2: string}>();
-    let {[Symbol.iterator]: iterator = () => get<IterableIterator<number>>()} = [1];
+    const {[propName3]: computed3 = null} = get<{1: string, 2: string}>();
+    const {[Symbol.iterator]: iterator = () => get<IterableIterator<string>>()} = [1];
     let {nested: {prop: nestedProp = 'nestedProp'} = obj} = get<{nested: typeof obj}>();
     let {toString = () => 'foo'} = 1;
 

--- a/baselines/packages/mimir/test/no-useless-initializer/project-loose/test.ts.fix
+++ b/baselines/packages/mimir/test/no-useless-initializer/project-loose/test.ts.fix
@@ -66,7 +66,13 @@ declare function get<T>(): T;
     let {any = 'any'} = get<{any: any}>();
     let {unknown = 'unknown'} = get<{unknown: unknown}>();
     let {'prop': renamed = 'renamed'} = obj;
-    let {[get<'prop'>()]: computed = 'computed'} = obj;
+    const propName = 'prop';
+    let {[propName]: computed = 'computed'} = obj;
+    const propName2: string | 1 | 2 = null as any;
+    let {[propName2]: computed2 = 'computed'} = get<{[key: string]: string, 1: string, 2: string}>();
+    const propName3 = 1;
+    let {[propName3]: computed3 = 'computed'} = get<{1: string, 2: string}>();
+    let {[Symbol.iterator]: iterator = () => get<IterableIterator<number>>()} = [1];
     let {nested: {prop: nestedProp = 'nestedProp'} = obj} = get<{nested: typeof obj}>();
     let {toString = () => 'foo'} = 1;
 

--- a/baselines/packages/mimir/test/no-useless-initializer/project-loose/test.ts.lint
+++ b/baselines/packages/mimir/test/no-useless-initializer/project-loose/test.ts.lint
@@ -75,7 +75,13 @@ declare function get<T>(): T;
     let {any = 'any'} = get<{any: any}>();
     let {unknown = 'unknown'} = get<{unknown: unknown}>();
     let {'prop': renamed = 'renamed'} = obj;
-    let {[get<'prop'>()]: computed = 'computed'} = obj;
+    const propName = 'prop';
+    let {[propName]: computed = 'computed'} = obj;
+    const propName2: string | 1 | 2 = null as any;
+    let {[propName2]: computed2 = 'computed'} = get<{[key: string]: string, 1: string, 2: string}>();
+    const propName3 = 1;
+    let {[propName3]: computed3 = 'computed'} = get<{1: string, 2: string}>();
+    let {[Symbol.iterator]: iterator = () => get<IterableIterator<number>>()} = [1];
     let {nested: {prop: nestedProp = 'nestedProp'} = obj} = get<{nested: typeof obj}>();
     let {toString = () => 'foo'} = 1;
 

--- a/baselines/packages/mimir/test/no-useless-initializer/project-loose/test.ts.lint
+++ b/baselines/packages/mimir/test/no-useless-initializer/project-loose/test.ts.lint
@@ -76,12 +76,12 @@ declare function get<T>(): T;
     let {unknown = 'unknown'} = get<{unknown: unknown}>();
     let {'prop': renamed = 'renamed'} = obj;
     const propName = 'prop';
-    let {[propName]: computed = 'computed'} = obj;
-    const propName2: string | 1 | 2 = null as any;
-    let {[propName2]: computed2 = 'computed'} = get<{[key: string]: string, 1: string, 2: string}>();
+    const {[propName]: computed = null} = obj;
+    const propName2: string = null as any;
+    let {[propName2]: computed2 = ''} = get<{[key: string]: string}>();
     const propName3 = 1;
-    let {[propName3]: computed3 = 'computed'} = get<{1: string, 2: string}>();
-    let {[Symbol.iterator]: iterator = () => get<IterableIterator<number>>()} = [1];
+    const {[propName3]: computed3 = null} = get<{1: string, 2: string}>();
+    const {[Symbol.iterator]: iterator = () => get<IterableIterator<string>>()} = [1];
     let {nested: {prop: nestedProp = 'nestedProp'} = obj} = get<{nested: typeof obj}>();
     let {toString = () => 'foo'} = 1;
 

--- a/baselines/packages/mimir/test/no-useless-initializer/project/test.ts.fix
+++ b/baselines/packages/mimir/test/no-useless-initializer/project/test.ts.fix
@@ -67,12 +67,12 @@ declare function get<T>(): T;
     let {unknown = 'unknown'} = get<{unknown: unknown}>();
     let {'prop': renamed} = obj;
     const propName = 'prop';
-    let {[propName]: computed} = obj;
-    const propName2: string | 1 | 2 = null as any;
-    let {[propName2]: computed2 = 'computed'} = get<{[key: string]: string, 1: string, 2: string}>();
+    const {[propName]: computed = null} = obj;
+    const propName2: string = null as any;
+    let {[propName2]: computed2 = ''} = get<{[key: string]: string}>();
     const propName3 = 1;
-    let {[propName3]: computed3} = get<{1: string, 2: string}>();
-    let {[Symbol.iterator]: iterator} = [1];
+    const {[propName3]: computed3 = null} = get<{1: string, 2: string}>();
+    const {[Symbol.iterator]: iterator = () => get<IterableIterator<string>>()} = [1];
     let {nested: {prop: nestedProp}} = get<{nested: typeof obj}>();
     let {toString} = 1;
 

--- a/baselines/packages/mimir/test/no-useless-initializer/project/test.ts.fix
+++ b/baselines/packages/mimir/test/no-useless-initializer/project/test.ts.fix
@@ -66,7 +66,13 @@ declare function get<T>(): T;
     let {any = 'any'} = get<{any: any}>();
     let {unknown = 'unknown'} = get<{unknown: unknown}>();
     let {'prop': renamed} = obj;
-    let {[get<'prop'>()]: computed = 'computed'} = obj;
+    const propName = 'prop';
+    let {[propName]: computed} = obj;
+    const propName2: string | 1 | 2 = null as any;
+    let {[propName2]: computed2 = 'computed'} = get<{[key: string]: string, 1: string, 2: string}>();
+    const propName3 = 1;
+    let {[propName3]: computed3} = get<{1: string, 2: string}>();
+    let {[Symbol.iterator]: iterator} = [1];
     let {nested: {prop: nestedProp}} = get<{nested: typeof obj}>();
     let {toString} = 1;
 

--- a/baselines/packages/mimir/test/no-useless-initializer/project/test.ts.lint
+++ b/baselines/packages/mimir/test/no-useless-initializer/project/test.ts.lint
@@ -81,7 +81,16 @@ declare function get<T>(): T;
     let {unknown = 'unknown'} = get<{unknown: unknown}>();
     let {'prop': renamed = 'renamed'} = obj;
                            ~~~~~~~~~         [error no-useless-initializer: Unnecessary default value as this property is never 'undefined'.]
-    let {[get<'prop'>()]: computed = 'computed'} = obj;
+    const propName = 'prop';
+    let {[propName]: computed = 'computed'} = obj;
+                                ~~~~~~~~~~         [error no-useless-initializer: Unnecessary default value as this property is never 'undefined'.]
+    const propName2: string | 1 | 2 = null as any;
+    let {[propName2]: computed2 = 'computed'} = get<{[key: string]: string, 1: string, 2: string}>();
+    const propName3 = 1;
+    let {[propName3]: computed3 = 'computed'} = get<{1: string, 2: string}>();
+                                  ~~~~~~~~~~                                   [error no-useless-initializer: Unnecessary default value as this property is never 'undefined'.]
+    let {[Symbol.iterator]: iterator = () => get<IterableIterator<number>>()} = [1];
+                                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~         [error no-useless-initializer: Unnecessary default value as this property is never 'undefined'.]
     let {nested: {prop: nestedProp = 'nestedProp'} = obj} = get<{nested: typeof obj}>();
                                      ~~~~~~~~~~~~                                        [error no-useless-initializer: Unnecessary default value as this property is never 'undefined'.]
                                                      ~~~                                 [error no-useless-initializer: Unnecessary default value as this property is never 'undefined'.]

--- a/baselines/packages/mimir/test/no-useless-initializer/project/test.ts.lint
+++ b/baselines/packages/mimir/test/no-useless-initializer/project/test.ts.lint
@@ -82,15 +82,15 @@ declare function get<T>(): T;
     let {'prop': renamed = 'renamed'} = obj;
                            ~~~~~~~~~         [error no-useless-initializer: Unnecessary default value as this property is never 'undefined'.]
     const propName = 'prop';
-    let {[propName]: computed = 'computed'} = obj;
-                                ~~~~~~~~~~         [error no-useless-initializer: Unnecessary default value as this property is never 'undefined'.]
-    const propName2: string | 1 | 2 = null as any;
-    let {[propName2]: computed2 = 'computed'} = get<{[key: string]: string, 1: string, 2: string}>();
+    const {[propName]: computed = null} = obj;
+                                  ~~~~         [error no-useless-initializer: Unnecessary default value as this property is never 'undefined'.]
+    const propName2: string = null as any;
+    let {[propName2]: computed2 = ''} = get<{[key: string]: string}>();
     const propName3 = 1;
-    let {[propName3]: computed3 = 'computed'} = get<{1: string, 2: string}>();
-                                  ~~~~~~~~~~                                   [error no-useless-initializer: Unnecessary default value as this property is never 'undefined'.]
-    let {[Symbol.iterator]: iterator = () => get<IterableIterator<number>>()} = [1];
-                                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~         [error no-useless-initializer: Unnecessary default value as this property is never 'undefined'.]
+    const {[propName3]: computed3 = null} = get<{1: string, 2: string}>();
+                                    ~~~~                                   [error no-useless-initializer: Unnecessary default value as this property is never 'undefined'.]
+    const {[Symbol.iterator]: iterator = () => get<IterableIterator<string>>()} = [1];
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~         [error no-useless-initializer: Unnecessary default value as this property is never 'undefined'.]
     let {nested: {prop: nestedProp = 'nestedProp'} = obj} = get<{nested: typeof obj}>();
                                      ~~~~~~~~~~~~                                        [error no-useless-initializer: Unnecessary default value as this property is never 'undefined'.]
                                                      ~~~                                 [error no-useless-initializer: Unnecessary default value as this property is never 'undefined'.]

--- a/packages/mimir/src/rules/no-unstable-api-use.ts
+++ b/packages/mimir/src/rules/no-unstable-api-use.ts
@@ -73,7 +73,7 @@ export class Rule extends TypedRule {
                 } else {
                     for (const {symbol, name} of propertiesOfType(
                             type,
-                            lateBoundPropertyNames((<ts.ComputedPropertyName>element.propertyName).expression!, this.checker),
+                            lateBoundPropertyNames((<ts.ComputedPropertyName>element.propertyName).expression!, this.checker).properties,
                         )
                     )
                         this.checkStability(symbol, element.propertyName, name, describeWithName);

--- a/packages/mimir/test/no-useless-initializer/test.ts
+++ b/packages/mimir/test/no-useless-initializer/test.ts
@@ -67,12 +67,12 @@ declare function get<T>(): T;
     let {unknown = 'unknown'} = get<{unknown: unknown}>();
     let {'prop': renamed = 'renamed'} = obj;
     const propName = 'prop';
-    let {[propName]: computed = 'computed'} = obj;
-    const propName2: string | 1 | 2 = null as any;
-    let {[propName2]: computed2 = 'computed'} = get<{[key: string]: string, 1: string, 2: string}>();
+    const {[propName]: computed = null} = obj;
+    const propName2: string = null as any;
+    let {[propName2]: computed2 = ''} = get<{[key: string]: string}>();
     const propName3 = 1;
-    let {[propName3]: computed3 = 'computed'} = get<{1: string, 2: string}>();
-    let {[Symbol.iterator]: iterator = () => get<IterableIterator<number>>()} = [1];
+    const {[propName3]: computed3 = null} = get<{1: string, 2: string}>();
+    const {[Symbol.iterator]: iterator = () => get<IterableIterator<string>>()} = [1];
     let {nested: {prop: nestedProp = 'nestedProp'} = obj} = get<{nested: typeof obj}>();
     let {toString = () => 'foo'} = 1;
 

--- a/packages/mimir/test/no-useless-initializer/test.ts
+++ b/packages/mimir/test/no-useless-initializer/test.ts
@@ -66,7 +66,13 @@ declare function get<T>(): T;
     let {any = 'any'} = get<{any: any}>();
     let {unknown = 'unknown'} = get<{unknown: unknown}>();
     let {'prop': renamed = 'renamed'} = obj;
-    let {[get<'prop'>()]: computed = 'computed'} = obj;
+    const propName = 'prop';
+    let {[propName]: computed = 'computed'} = obj;
+    const propName2: string | 1 | 2 = null as any;
+    let {[propName2]: computed2 = 'computed'} = get<{[key: string]: string, 1: string, 2: string}>();
+    const propName3 = 1;
+    let {[propName3]: computed3 = 'computed'} = get<{1: string, 2: string}>();
+    let {[Symbol.iterator]: iterator = () => get<IterableIterator<number>>()} = [1];
     let {nested: {prop: nestedProp = 'nestedProp'} = obj} = get<{nested: typeof obj}>();
     let {toString = () => 'foo'} = 1;
 


### PR DESCRIPTION
#### Checklist

- [x] Fixes: ##310
- [x] Added or updated tests / baselines

#### Overview of change 
Fail if the computed name
* only consists of string or number literal types
* each type has a symbol
* symbol is not optional or includes `undefined` in its type