### PR TITLE
ProjectHost: release unreferenced SourceFiles

### DIFF
--- a/baselines/packages/wotan/test/project/fix/default/test.ts.lint
+++ b/baselines/packages/wotan/test/project/fix/default/test.ts.lint
@@ -3,3 +3,5 @@ import {foo as fn} from './other';
 foo: bar: <string>fn();
 ~~~                     [error no-unused-label: Unused label 'foo'.]
      ~~~                [error no-unused-label: Unused label 'bar'.]
+import {v} from './zzz';
+~~~~~~~~~~~~~~~~~~~~~~~~ [error local/foo: import is unused]

--- a/packages/wotan/src/project-host.ts
+++ b/packages/wotan/src/project-host.ts
@@ -15,7 +15,7 @@ const additionalExtensions = ['.json'];
 // @internal
 export interface ProcessedFileInfo {
     originalName: string;
-    originalContent: string;
+    originalContent: string; // TODO this should move into processor because this property is never updated, but the processor is
     processor: AbstractProcessor;
 }
 
@@ -202,5 +202,12 @@ export class ProjectHost implements ts.CompilerHost {
         this.sourceFileCache.set(sourceFile.fileName, sourceFile);
         program = ts.createProgram(program.getRootFileNames(), program.getCompilerOptions(), this, program);
         return {sourceFile, program};
+    }
+
+    public onReleaseOldSourceFile(sourceFile: ts.SourceFile) {
+        // this is only called for paths that are no longer referenced
+        // it's safe to remove the cache entry completely because it won't be called with updated SourceFiles
+        this.sourceFileCache.delete(sourceFile.fileName);
+        this.processedFiles.delete(sourceFile.fileName);
     }
 }

--- a/packages/wotan/test/project/fix/foo.js
+++ b/packages/wotan/test/project/fix/foo.js
@@ -1,8 +1,16 @@
+// @ts-check
 const {AbstractRule, Replacement} = require('@fimbul/ymir');
 
 exports.Rule = class extends AbstractRule {
     apply() {
         if (this.sourceFile.text.substring(8, 11) === 'foo')
             this.addFailure(8, 11, "'foo' is not allowed.", Replacement.replace(8, 11, 'bar'));
+        if (this.sourceFile.statements.length === 3) {
+            this.addFailureAtNode(
+                this.sourceFile.statements[2],
+                'import is unused',
+                Replacement.delete(this.sourceFile.statements[2].pos, this.sourceFile.statements[2].end),
+            );
+        }
     }
 }

--- a/packages/wotan/test/project/fix/other.ts
+++ b/packages/wotan/test/project/fix/other.ts
@@ -1,6 +1,6 @@
 export function bar(): string {
     return 'bar';
 }
-export function foo(): string | number{
+export function foo(): string | number {
     return 'foo';
 }

--- a/packages/wotan/test/project/fix/test.ts
+++ b/packages/wotan/test/project/fix/test.ts
@@ -1,2 +1,3 @@
 import {foo as fn} from './other';
 foo: bar: <string>fn();
+import {v} from './zzz';

--- a/packages/wotan/test/project/fix/tsconfig.json
+++ b/packages/wotan/test/project/fix/tsconfig.json
@@ -1,5 +1,9 @@
 {
   "compilerOptions": {
     "strict": true
-  }
+  },
+  "files": [
+    "test.ts",
+    "invalid.ts"
+  ]
 }

--- a/packages/wotan/test/project/fix/zzz.ts
+++ b/packages/wotan/test/project/fix/zzz.ts
@@ -1,0 +1,2 @@
+// the reference to this file is removed by an autofix
+export const v = 0;


### PR DESCRIPTION
#### Checklist

- [x] Mildly related to: #364 
- [x] Added or updated tests / baselines

#### Overview of change 
Release cache for SourceFiles that are no longer referenced by the Program. This may prevent unnecessary memory allocation on large projects with many fixes.