### PR TITLE
Wotan README recommends single quote, but Quick Start uses double quote.

### DIFF
--- a/packages/wotan/README.md
+++ b/packages/wotan/README.md
@@ -34,7 +34,7 @@ Now you can run the linter with one of the following commands depending on your 
 
 ```sh
 wotan -p <path/to/tsconfig.json> # lint the whole project
-wotan "src/**/*.ts" -e "**/*.d.ts" # lint all typescript files excluding declaration files
+wotan 'src/**/*.ts' -e '**/*.d.ts' # lint all typescript files excluding declaration files
 wotan --fix # lint the whole project and fix all fixable errors
 ```
 


### PR DESCRIPTION
#### Checklist

- [x] Fixes: Not applicable
- [x] Added or updated tests / baselines
- [x] Documentation update

#### Overview of change

[Wotan README](https://github.com/fimbullinter/wotan/blob/master/packages/wotan/README.md#cli-options) says,

> -e --exclude <glob> excludes all files that match the given glob pattern from linting. This option can be used multiple times to specify multiple patterns. For example -e '**/*.js' -e '**/*.d.ts'. It is recommended to wrap the glob patterns in single quotes to prevent the shell from expanding them.

...and while all other examples in the doc use single quote, the example in the Quick Start section uses double quote, which can be thought as a reference.