### PR TITLE
CI: test mixed case paths on case sensitive file system

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,7 @@ workflows:
             - build
 
 base: &base
+  working_directory: '~/Project' # to really test case sensitivity
   steps:
     - checkout
     - attach_workspace:
@@ -36,6 +37,7 @@ base: &base
 version: 2
 jobs:
   build:
+    working_directory: '~/Project'
     docker:
       - image: circleci/node:10@sha256:37a9958a87a806664578bca2cc721ab1886aee95efc3771ddb9051bdd33960f3
     steps:

--- a/packages/wotan/src/project-host.ts
+++ b/packages/wotan/src/project-host.ts
@@ -229,7 +229,7 @@ export class ProjectHost implements ts.CompilerHost {
         newContent: string,
         _changeRange: ts.TextChangeRange,
     ): {sourceFile: ts.SourceFile, program: ts.Program} {
-        // TODO use updateSourceFile once https://github.com/Microsoft/TypeScript/issues/26166 is resolved
+        // this doesn't use 'ts.updateSourceFile' for compatibility with TypeScript@<3.1.0
         sourceFile = ts.createSourceFile(sourceFile.fileName, newContent, sourceFile.languageVersion, true);
         this.sourceFileCache.set(sourceFile.fileName, sourceFile);
         const references = program.getProjectReferences && // for compatibility with TypeScript@<3.0.0

--- a/packages/wotan/src/runner.ts
+++ b/packages/wotan/src/runner.ts
@@ -372,6 +372,7 @@ function getOutputFileNamesOfProjectReference(projectDirectory: string, commandL
     return mapDefined(commandLine.fileNames, (fileName) => getDeclarationOutputName(fileName, options, projectDirectory));
 }
 
+// TODO remove once https://github.com/Microsoft/TypeScript/issues/26410 is resolved
 function getDeclarationOutputName(fileName: string, options: ts.CompilerOptions, projectDirectory: string) {
     const extension = path.extname(fileName);
     switch (extension) {

--- a/packages/wotan/src/services/default/file-system.ts
+++ b/packages/wotan/src/services/default/file-system.ts
@@ -6,10 +6,13 @@ import * as ts from 'typescript';
 
 @injectable()
 export class NodeFileSystem implements FileSystem {
+    public static normalizePath(path: string) {
+        return unixifyPath(ts.sys.useCaseSensitiveFileNames ? path : path.toLowerCase());
+    }
     constructor(private logger: MessageHandler) {}
 
     public normalizePath(path: string) {
-        return unixifyPath(ts.sys.useCaseSensitiveFileNames ? path : path.toLowerCase());
+        return NodeFileSystem.normalizePath(path);
     }
     public readFile(file: string) {
         const buf = fs.readFileSync(file);

--- a/packages/wotan/test/commands.spec.ts
+++ b/packages/wotan/test/commands.spec.ts
@@ -144,7 +144,7 @@ test('ShowCommand', async (t) => {
     }
     function normalizePaths(str: string): string {
         // replace `cwd` with / and all backslashes with forward slash
-        const re = new RegExp(`(- )?(['"]?)${escapeRegex(cwd)}(.*?)\\2(,?)$`, 'gm');
+        const re = new RegExp(`(- )?(['"]?)${escapeRegex(cwd)}(.*?)\\2(,?)$`, 'gmi');
         return str.replace(/\\\\/g, '\\').replace(re, (_, dash, quote, p, comma) => dash && !comma
             ? dash + unixifyPath(p)
             : quote + unixifyPath(p) + quote + comma);
@@ -319,7 +319,7 @@ test('LintCommand', async (t) => {
         error() { throw new Error(); },
     });
 
-    const cwd = path.join(__dirname, 'fixtures/test').toLowerCase();
+    const cwd = path.join(__dirname, 'fixtures/test');
     container.bind(DirectoryService).toConstantValue({
         getCurrentDirectory() { return cwd; },
     });
@@ -395,7 +395,7 @@ ERROR 2:8  no-unused-expression  This expression is unused. Did you mean to assi
         true,
     );
     t.deepEqual(filesWritten, {
-        [unixifyPath(path.join(cwd, '3.ts'))]: `"bar";\n'baz';\n`,
+        [NodeFileSystem.normalizePath(path.join(cwd, '3.ts'))]: `"bar";\n'baz';\n`,
     });
     t.is(output.join('\n'), 'Automatically fixed 1 failure.');
 
@@ -431,7 +431,7 @@ ERROR 2:1  no-unused-label  Unused label 'label'.
 });
 
 test('TestCommand', async (t) => {
-    let cwd = path.join(__dirname, 'fixtures').toLowerCase();
+    let cwd = path.join(__dirname, 'fixtures');
     const directories: DirectoryService = {
         getCurrentDirectory() { return cwd; },
     };
@@ -654,15 +654,15 @@ ${path.normalize('test/.fail-fix.test.json')}
             },
         );
         t.deepEqual(deleted, [
-            unixifyPath(path.resolve(cwd, 'baselines/.fail-fix/1.ts.fix')),
-            unixifyPath(path.resolve(cwd, 'baselines/.fail-fix/2.ts.fix')),
+            NodeFileSystem.normalizePath(path.resolve(cwd, 'baselines/.fail-fix/1.ts.fix')),
+            NodeFileSystem.normalizePath(path.resolve(cwd, 'baselines/.fail-fix/2.ts.fix')),
         ]);
         t.deepEqual(written, {
-            [unixifyPath(path.resolve(cwd, 'baselines/.fail-fix/1.ts.lint'))]: 'export {};\n',
-            [unixifyPath(path.resolve(cwd, 'baselines/.fail-fix/2.ts.lint'))]: "export {};\n'foo';\n",
-            [unixifyPath(path.resolve(cwd, 'baselines/.fail-fix/3.ts.lint'))]:
+            [NodeFileSystem.normalizePath(path.resolve(cwd, 'baselines/.fail-fix/1.ts.lint'))]: 'export {};\n',
+            [NodeFileSystem.normalizePath(path.resolve(cwd, 'baselines/.fail-fix/2.ts.lint'))]: "export {};\n'foo';\n",
+            [NodeFileSystem.normalizePath(path.resolve(cwd, 'baselines/.fail-fix/3.ts.lint'))]:
                 `"bar";\nlabel: 'baz';\n~~~~~         [error no-unused-label: Unused label 'label'.]\n`,
-            [unixifyPath(path.resolve(cwd, 'baselines/.fail-fix/3.ts.fix'))]: `"bar";\n'baz';\n`,
+            [NodeFileSystem.normalizePath(path.resolve(cwd, 'baselines/.fail-fix/3.ts.fix'))]: `"bar";\n'baz';\n`,
         });
     }
 
@@ -718,14 +718,14 @@ ${path.normalize('test/.success.test.json')}
         );
 
         t.deepEqual(written, {
-            [unixifyPath(path.resolve(cwd, 'baselines/.success/1.ts.lint'))]: 'export {};\n',
-            [unixifyPath(path.resolve(cwd, 'baselines/.success/2.ts.lint'))]: "export {};\n'foo';\n",
-            [unixifyPath(path.resolve(cwd, 'baselines/.success/3.ts.lint'))]: `"bar";\nlabel: 'baz';\n`,
+            [NodeFileSystem.normalizePath(path.resolve(cwd, 'baselines/.success/1.ts.lint'))]: 'export {};\n',
+            [NodeFileSystem.normalizePath(path.resolve(cwd, 'baselines/.success/2.ts.lint'))]: "export {};\n'foo';\n",
+            [NodeFileSystem.normalizePath(path.resolve(cwd, 'baselines/.success/3.ts.lint'))]: `"bar";\nlabel: 'baz';\n`,
         });
         t.deepEqual(directoriesCreated, [
-            unixifyPath(path.join(cwd, 'baselines/.success')),
-            unixifyPath(path.join(cwd, 'baselines')),
-            unixifyPath(path.join(cwd, 'baselines/.success')),
+            NodeFileSystem.normalizePath(path.join(cwd, 'baselines/.success')),
+            NodeFileSystem.normalizePath(path.join(cwd, 'baselines')),
+            NodeFileSystem.normalizePath(path.join(cwd, 'baselines/.success')),
         ]);
     }
 
@@ -820,8 +820,8 @@ ${path.normalize('.fail-fix.test.json')}
         );
 
         t.deepEqual(deleted, [
-            unixifyPath(path.resolve(cwd, 'baselines/.fail-fix/4.ts.fix')),
-            unixifyPath(path.resolve(cwd, 'baselines/.fail-fix/4.ts.lint')),
+            NodeFileSystem.normalizePath(path.resolve(cwd, 'baselines/.fail-fix/4.ts.fix')),
+            NodeFileSystem.normalizePath(path.resolve(cwd, 'baselines/.fail-fix/4.ts.lint')),
         ]);
     }
 


### PR DESCRIPTION
This ensures tests (and or course the application) work as expected on case sensitive file systems with mixed case paths.