### PR TITLE
Allow FileSystem.readDirectory to return Array<string|Dirent>

### DIFF
--- a/packages/wotan/src/services/default/file-system.ts
+++ b/packages/wotan/src/services/default/file-system.ts
@@ -1,4 +1,4 @@
-import { FileSystem, Stats, MessageHandler } from '@fimbul/ymir';
+import { FileSystem, Stats, MessageHandler, Dirent } from '@fimbul/ymir';
 import * as fs from 'fs';
 import { injectable } from 'inversify';
 import { unixifyPath } from '../../utils';
@@ -35,7 +35,7 @@ export class NodeFileSystem implements FileSystem {
         }
         return buf.toString('utf8'); // default to UTF8 without BOM
     }
-    public readDirectory(dir: string) {
+    public readDirectory(dir: string): Array<string | Dirent> {
         return fs.readdirSync(dir, <any>{withFileTypes: true});
     }
     public stat(path: string): Stats {

--- a/packages/wotan/src/services/default/file-system.ts
+++ b/packages/wotan/src/services/default/file-system.ts
@@ -36,7 +36,7 @@ export class NodeFileSystem implements FileSystem {
         return buf.toString('utf8'); // default to UTF8 without BOM
     }
     public readDirectory(dir: string) {
-        return fs.readdirSync(dir);
+        return fs.readdirSync(dir, <any>{withFileTypes: true});
     }
     public stat(path: string): Stats {
         return fs.statSync(path);

--- a/packages/wotan/test/cached-file-system.spec.ts
+++ b/packages/wotan/test/cached-file-system.spec.ts
@@ -1,0 +1,118 @@
+import test from 'ava';
+import { CachedFileSystem, FileKind } from '../src/services/cached-file-system';
+import { DefaultCacheFactory } from '../src/services/default/cache-factory';
+import { NodeFileSystem } from '../src/services/default/file-system';
+import { MessageHandler, Dirent } from '@fimbul/ymir';
+
+const dummyLogger: MessageHandler = {
+    log() {},
+    warn() {},
+    error() {},
+};
+
+function makeDirent(name: string, kind: 'FILE' | 'DIR' | 'SYMLINK') {
+    return {
+        name,
+        isFile() {
+            return kind === 'FILE';
+        },
+        isDirectory() {
+            return kind === 'DIR';
+        },
+        isSymbolicLink() {
+            return kind === 'SYMLINK';
+        },
+    };
+}
+
+function makeStat(kind: 'FILE' | 'DIR' | 'OTHER') {
+    return {
+        isFile() {
+            return kind === 'FILE';
+        },
+        isDirectory() {
+            return kind === 'DIR';
+        },
+    };
+}
+
+test('readDirectory', (t) => {
+    let throwError = false;
+    const fs = new CachedFileSystem(
+        new class extends NodeFileSystem {
+            public readDirectory(dir: string): Array<string | Dirent> {
+                if (throwError)
+                    throw new Error('unexpected IO operation');
+                switch (dir) {
+                    case '/plain':
+                        return ['a', 'b'];
+                    case '/dirent':
+                        return [
+                            makeDirent('dir', 'DIR'),
+                            makeDirent('file', 'FILE'),
+                            makeDirent('link', 'SYMLINK'),
+                        ];
+                    case '/mixed':
+                        return [
+                            'a',
+                            makeDirent('b', 'FILE'),
+                        ];
+                    default:
+                        throw new Error('ENOENT');
+                }
+            }
+            public stat(file: string) {
+                if (throwError)
+                    throw new Error('unexpected IO operation');
+                switch (file) {
+                    case '/plain/a':
+                        return makeStat('FILE');
+                    case '/plain/b':
+                        return makeStat('DIR');
+                    case '/dirent/link':
+                        return makeStat('FILE');
+                    case '/mixed/a':
+                        return makeStat('OTHER');
+                    default:
+                        throw new Error('not expected');
+                }
+            }
+        }(dummyLogger),
+        new DefaultCacheFactory(),
+    );
+
+    t.deepEqual(
+        fs.readDirectory('/plain'),
+        [{name: 'a', kind: FileKind.File}, {name: 'b', kind: FileKind.Directory}],
+        'converts plain strings',
+    );
+
+    t.deepEqual(
+        fs.readDirectory('/dirent'),
+        [{name: 'dir', kind: FileKind.Directory}, {name: 'file', kind: FileKind.File}, {name: 'link', kind: FileKind.File}],
+        'handles Dirent and symlinks',
+    );
+
+    t.deepEqual(
+        fs.readDirectory('/mixed'),
+        [{name: 'a', kind: FileKind.Other}, {name: 'b', kind: FileKind.File}],
+        'handles mixed string and Dirent array',
+    );
+
+    t.throws(() => fs.readDirectory('/non-existent'), 'ENOENT');
+
+    // ensure values are cached
+    throwError = true;
+    // fs.readDirectory('/plain');
+    // fs.readDirectory('/dirent');
+    // fs.readDirectory('/mixed');
+
+    t.true(fs.isDirectory('/plain/b'));
+    t.false(fs.isDirectory('/plain/a'));
+    t.true(fs.isFile('/plain/a'));
+    t.true(fs.isDirectory('/dirent/dir'));
+    t.false(fs.isDirectory('/dirent/file'));
+    t.true(fs.isFile('/dirent/file'));
+    t.false(fs.isDirectory('/mixed/a'));
+    t.false(fs.isDirectory('/mixed/a'));
+});

--- a/packages/wotan/test/cached-file-system.spec.ts
+++ b/packages/wotan/test/cached-file-system.spec.ts
@@ -57,6 +57,11 @@ test('readDirectory', (t) => {
                             'a',
                             makeDirent('b', 'FILE'),
                         ];
+                    case '/':
+                        return [
+                            'a',
+                            makeDirent('b', 'SYMLINK'),
+                        ];
                     default:
                         throw new Error('ENOENT');
                 }
@@ -73,6 +78,10 @@ test('readDirectory', (t) => {
                         return makeStat('FILE');
                     case '/mixed/a':
                         return makeStat('OTHER');
+                    case '/a':
+                        return makeStat('FILE');
+                    case '/b':
+                        return makeStat('DIR');
                     default:
                         throw new Error('not expected');
                 }
@@ -99,6 +108,12 @@ test('readDirectory', (t) => {
         'handles mixed string and Dirent array',
     );
 
+    t.deepEqual(
+        fs.readDirectory('/'),
+        [{name: 'a', kind: FileKind.File}, {name: 'b', kind: FileKind.Directory}],
+        'correctly handles root directory',
+    );
+
     t.throws(() => fs.readDirectory('/non-existent'), 'ENOENT');
 
     // ensure values are cached
@@ -115,4 +130,5 @@ test('readDirectory', (t) => {
     t.true(fs.isFile('/dirent/file'));
     t.false(fs.isDirectory('/mixed/a'));
     t.false(fs.isDirectory('/mixed/a'));
+    t.true(fs.isDirectory('/b'));
 });

--- a/packages/ymir/src/index.ts
+++ b/packages/ymir/src/index.ts
@@ -380,8 +380,8 @@ export interface FileSystem {
     normalizePath(path: string): string;
     /** Reads the given file. Tries to infer and convert encoding. */
     readFile(file: string): string;
-    /** Reads directory entries. Returns only the basenames. */
-    readDirectory(dir: string): string[];
+    /** Reads directory entries. Returns only the basenames optionally with file type information. */
+    readDirectory(dir: string): Array<string | Dirent>;
     /** Gets the status of a file or directory. */
     stat(path: string): Stats;
     /** Gets the realpath of a given file or directory. */
@@ -398,6 +398,11 @@ export abstract class FileSystem {}
 export interface Stats {
     isDirectory(): boolean;
     isFile(): boolean;
+}
+
+export interface Dirent extends Stats {
+    name: string;
+    isSymbolicLink(): boolean;
 }
 
 export interface RuleLoaderHost {


### PR DESCRIPTION
#### Checklist

- [x] Fixes: #413 
- [x] Added or updated tests / baselines

#### Overview of change 
This uses the new Node.js option `{withFileTypes: true}` if available to avoid useless file system calls.
It caches the kind if provided and needs to look up the real type for symlinks.

Caching of directory entries will be done in a separate PR.