### PR TITLE
fixer: merge adjacent insertion replacements of a single fix

### DIFF
--- a/docs/writing-rules.md
+++ b/docs/writing-rules.md
@@ -193,24 +193,31 @@ this.addFailure(start, end, "Type 'any' is forbidden.", [
 
 Both fixes above are treated the same internally. But there are certain restrictions:
 While overlapping replacements of different fixes are filtered out and applied in a subsequent iteration, replacements of the same fix must not overlap.
+Replacements of the same fix are not considered overlapping if their ranges are touching.
 
 * No `replace` or `delete` of the same character more than once.
-* No `replace` or `append` at the same position more than once.
 * You are allowed to `delete` and `append` at the same position as they get merged internally.
+* `append`ing multiple times at the same position merges the insertions in order of occurrence.
 
-Some examples of invalid fixes:
+Some examples:
 
 ```ts
 [
   Replacement.delete(start, end),
   Replacement.append(start, '{'),
-  Replacement.append(start, '}'), // overlaps with the previous replacement
+  Replacement.append(start, '}'),
 ];
+// same as
+Replacement.replace(start, end, '{}');
+
 
 [
   Replacement.replace(start, end, '{'),
-  Replacement.append(start, '}'), // overlaps with the previous replacement
+  Replacement.append(start, '}'), // order matters, swapping with the previous line gives a different result
 ];
+// same as
+Replacement.replace(start, end, '{}');
+
 
 [
   Replacement.delete(start, end),

--- a/packages/wotan/package.json
+++ b/packages/wotan/package.json
@@ -62,6 +62,7 @@
     "reflect-metadata": "^0.1.12",
     "resolve": "^1.5.0",
     "semver": "^5.4.1",
+    "stable": "^0.1.8",
     "to-absolute-glob": "^2.0.2",
     "tslib": "^1.8.1",
     "tsutils": "^3.0.0"

--- a/packages/wotan/test/fix.spec.ts
+++ b/packages/wotan/test/fix.spec.ts
@@ -78,10 +78,42 @@ test('Fixer', (t) => {
         'merges replacements of a fix',
     );
 
-    t.throws(
-        () => applyFixes('', [{replacements: [Replacement.append(0, 'a'), Replacement.append(0, 'b')]}]),
-        'Multiple insertion replacements at the same position.',
+    t.deepEqual(
+        applyFixes('abc', [
+            {replacements: [Replacement.replace(0, 1, 'd'), Replacement.replace(1, 2, 'e')]},
+        ]),
+        {
+            result: 'dec',
+            fixed: 1,
+            range: {
+                span: {
+                    start: 0,
+                    length: 2,
+                },
+                newLength: 2,
+            },
+        },
+        'merges touching replacements of a fix',
     );
+
+    t.deepEqual(
+        applyFixes('', [
+            {replacements: [Replacement.append(0, 'a'), Replacement.append(0, 'b')]},
+        ]),
+        {
+            result: 'ab',
+            fixed: 1,
+            range: {
+                span: {
+                    start: 0,
+                    length: 0,
+                },
+                newLength: 2,
+            },
+        },
+        'merges insertions at the same position of a fix',
+    );
+
     t.throws(
         () => applyFixes('', [{replacements: [Replacement.delete(1, 4), Replacement.replace(1, 4, 'b')]}]),
         'Replacements of fix overlap.',

--- a/yarn.lock
+++ b/yarn.lock
@@ -4007,6 +4007,10 @@ sshpk@^1.7.0:
     jsbn "~0.1.0"
     tweetnacl "~0.14.0"
 
+stable@^0.1.8:
+  version "0.1.8"
+  resolved "https://registry.yarnpkg.com/stable/-/stable-0.1.8.tgz#836eb3c8382fe2936feaf544631017ce7d47a3cf"
+
 stack-utils@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/stack-utils/-/stack-utils-1.0.1.tgz#d4f33ab54e8e38778b0ca5cfd3b3afb12db68620"


### PR DESCRIPTION
Encountered this while working on #434 

We now trust the developer of the rule that adjacent replacements of a fix are intended to be applied this way. This requires a stable sorting algorithm as `Array.prorotype.sort` is not deterministic and might shuffle entries with the same sort value.
