### PR TITLE
FileSystem: use recursive mkdirSync if available

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@types/cross-spawn": "^6.0.0",
     "@types/github-url-to-object": "^4.0.0",
     "@types/glob": "^5.0.35",
-    "@types/node": "^10.0.8",
+    "@types/node": "^10.12.0",
     "@types/parse5-sax-parser": "^5.0.1",
     "ava": "^0.25.0",
     "codecov": "^3.0.0",

--- a/packages/wotan/package.json
+++ b/packages/wotan/package.json
@@ -37,7 +37,6 @@
     "@types/json5": "0.0.30",
     "@types/minimatch": "^3.0.1",
     "@types/mkdirp": "^0.5.2",
-    "@types/node": "^9.3.0",
     "@types/resolve": "^0.0.8",
     "@types/rimraf": "^2.0.2",
     "@types/semver": "^5.4.0",

--- a/packages/wotan/src/services/default/file-system.ts
+++ b/packages/wotan/src/services/default/file-system.ts
@@ -36,7 +36,7 @@ export class NodeFileSystem implements FileSystem {
         return buf.toString('utf8'); // default to UTF8 without BOM
     }
     public readDirectory(dir: string): Array<string | Dirent> {
-        return fs.readdirSync(dir, <any>{withFileTypes: true});
+        return fs.readdirSync(dir, {withFileTypes: true});
     }
     public stat(path: string): Stats {
         return fs.statSync(path);
@@ -51,6 +51,6 @@ export class NodeFileSystem implements FileSystem {
         return fs.unlinkSync(path);
     }
     public createDirectory(dir: string): void {
-        return fs.mkdirSync(dir);
+        return fs.mkdirSync(dir, {recursive: true});
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -232,13 +232,13 @@
   dependencies:
     "@types/node" "*"
 
-"@types/node@*", "@types/node@^10.0.8":
+"@types/node@*":
   version "10.11.4"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.11.4.tgz#e8bd933c3f78795d580ae41d86590bfc1f4f389d"
 
-"@types/node@^9.3.0":
-  version "9.6.34"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-9.6.34.tgz#e03f9008f5fba43feb21223a82d3983531e004a2"
+"@types/node@^10.12.0":
+  version "10.12.0"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.12.0.tgz#ea6dcbddbc5b584c83f06c60e82736d8fbb0c235"
 
 "@types/parse5-sax-parser@^5.0.1":
   version "5.0.1"


### PR DESCRIPTION
Uses the newly added `recursive` option of `fs.mkdir(Sync)` if available. It falls back to the old behavior of creating parent directories one at a time.