### PR TITLE
no-useless-initializer: bugfix for destructuring when property is type variable

### DIFF
--- a/baselines/packages/mimir/test/no-useless-initializer/default/test.ts.fix
+++ b/baselines/packages/mimir/test/no-useless-initializer/default/test.ts.fix
@@ -101,3 +101,12 @@ declare function get<T>(): T;
     let {0: a = 1, 1: b = 2} = get<[number]>();
     let {0: c = 1, 1: d = 2} = get<[number, number]>();
 }
+
+function test<T, U extends any, V extends T, W extends string, X extends boolean | undefined>(param: {t: T, u: U, v: V, w: W, x: X}) {
+    let {t = '', u = '', v = '', w = '', x = ''} = param;
+    let {wx = ''} = get<{wx: W | X}>();
+}
+
+function test2<T>(t: T, u: T extends string ? boolean : undefined, v: T extends string ? string : boolean, w: T extends string ? T : number) {
+    let {t: _t = '', u: _u = '', v: _v = '', w: _w = ''} = get<{t: typeof t, u: typeof u, v: typeof v, w: typeof w}>();
+}

--- a/baselines/packages/mimir/test/no-useless-initializer/default/test.ts.lint
+++ b/baselines/packages/mimir/test/no-useless-initializer/default/test.ts.lint
@@ -110,3 +110,12 @@ declare function get<T>(): T;
     let {0: a = 1, 1: b = 2} = get<[number]>();
     let {0: c = 1, 1: d = 2} = get<[number, number]>();
 }
+
+function test<T, U extends any, V extends T, W extends string, X extends boolean | undefined>(param: {t: T, u: U, v: V, w: W, x: X}) {
+    let {t = '', u = '', v = '', w = '', x = ''} = param;
+    let {wx = ''} = get<{wx: W | X}>();
+}
+
+function test2<T>(t: T, u: T extends string ? boolean : undefined, v: T extends string ? string : boolean, w: T extends string ? T : number) {
+    let {t: _t = '', u: _u = '', v: _v = '', w: _w = ''} = get<{t: typeof t, u: typeof u, v: typeof v, w: typeof w}>();
+}

--- a/baselines/packages/mimir/test/no-useless-initializer/project-loose/test.ts.fix
+++ b/baselines/packages/mimir/test/no-useless-initializer/project-loose/test.ts.fix
@@ -101,3 +101,12 @@ declare function get<T>(): T;
     let {0: a = 1, 1: b = 2} = get<[number]>();
     let {0: c = 1, 1: d = 2} = get<[number, number]>();
 }
+
+function test<T, U extends any, V extends T, W extends string, X extends boolean | undefined>(param: {t: T, u: U, v: V, w: W, x: X}) {
+    let {t = '', u = '', v = '', w = '', x = ''} = param;
+    let {wx = ''} = get<{wx: W | X}>();
+}
+
+function test2<T>(t: T, u: T extends string ? boolean : undefined, v: T extends string ? string : boolean, w: T extends string ? T : number) {
+    let {t: _t = '', u: _u = '', v: _v = '', w: _w = ''} = get<{t: typeof t, u: typeof u, v: typeof v, w: typeof w}>();
+}

--- a/baselines/packages/mimir/test/no-useless-initializer/project-loose/test.ts.lint
+++ b/baselines/packages/mimir/test/no-useless-initializer/project-loose/test.ts.lint
@@ -110,3 +110,12 @@ declare function get<T>(): T;
     let {0: a = 1, 1: b = 2} = get<[number]>();
     let {0: c = 1, 1: d = 2} = get<[number, number]>();
 }
+
+function test<T, U extends any, V extends T, W extends string, X extends boolean | undefined>(param: {t: T, u: U, v: V, w: W, x: X}) {
+    let {t = '', u = '', v = '', w = '', x = ''} = param;
+    let {wx = ''} = get<{wx: W | X}>();
+}
+
+function test2<T>(t: T, u: T extends string ? boolean : undefined, v: T extends string ? string : boolean, w: T extends string ? T : number) {
+    let {t: _t = '', u: _u = '', v: _v = '', w: _w = ''} = get<{t: typeof t, u: typeof u, v: typeof v, w: typeof w}>();
+}

--- a/baselines/packages/mimir/test/no-useless-initializer/project/test.ts.fix
+++ b/baselines/packages/mimir/test/no-useless-initializer/project/test.ts.fix
@@ -101,3 +101,12 @@ declare function get<T>(): T;
     let {0: a = 1, 1: b = 2} = get<[number]>();
     let {0: c = 1, 1: d = 2} = get<[number, number]>();
 }
+
+function test<T, U extends any, V extends T, W extends string, X extends boolean | undefined>(param: {t: T, u: U, v: V, w: W, x: X}) {
+    let {t = '', u = '', v = '', w = '', x = ''} = param;
+    let {wx = ''} = get<{wx: W | X}>();
+}
+
+function test2<T>(t: T, u: T extends string ? boolean : undefined, v: T extends string ? string : boolean, w: T extends string ? T : number) {
+    let {t: _t = '', u: _u = '', v: _v = '', w: _w = ''} = get<{t: typeof t, u: typeof u, v: typeof v, w: typeof w}>();
+}

--- a/baselines/packages/mimir/test/no-useless-initializer/project/test.ts.lint
+++ b/baselines/packages/mimir/test/no-useless-initializer/project/test.ts.lint
@@ -126,3 +126,15 @@ declare function get<T>(): T;
     let {0: a = 1, 1: b = 2} = get<[number]>();
     let {0: c = 1, 1: d = 2} = get<[number, number]>();
 }
+
+function test<T, U extends any, V extends T, W extends string, X extends boolean | undefined>(param: {t: T, u: U, v: V, w: W, x: X}) {
+    let {t = '', u = '', v = '', w = '', x = ''} = param;
+                                     ~~                   [error no-useless-initializer: Unnecessary default value as this property is never 'undefined'.]
+    let {wx = ''} = get<{wx: W | X}>();
+}
+
+function test2<T>(t: T, u: T extends string ? boolean : undefined, v: T extends string ? string : boolean, w: T extends string ? T : number) {
+    let {t: _t = '', u: _u = '', v: _v = '', w: _w = ''} = get<{t: typeof t, u: typeof u, v: typeof v, w: typeof w}>();
+                                         ~~                                                                             [error no-useless-initializer: Unnecessary default value as this property is never 'undefined'.]
+                                                     ~~                                                                 [error no-useless-initializer: Unnecessary default value as this property is never 'undefined'.]
+}

--- a/packages/mimir/test/no-useless-initializer/test.ts
+++ b/packages/mimir/test/no-useless-initializer/test.ts
@@ -101,3 +101,12 @@ declare function get<T>(): T;
     let {0: a = 1, 1: b = 2} = get<[number]>();
     let {0: c = 1, 1: d = 2} = get<[number, number]>();
 }
+
+function test<T, U extends any, V extends T, W extends string, X extends boolean | undefined>(param: {t: T, u: U, v: V, w: W, x: X}) {
+    let {t = '', u = '', v = '', w = '', x = ''} = param;
+    let {wx = ''} = get<{wx: W | X}>();
+}
+
+function test2<T>(t: T, u: T extends string ? boolean : undefined, v: T extends string ? string : boolean, w: T extends string ? T : number) {
+    let {t: _t = '', u: _u = '', v: _v = '', w: _w = ''} = get<{t: typeof t, u: typeof u, v: typeof v, w: typeof w}>();
+}


### PR DESCRIPTION
#### Checklist

- [x] Fixes: #440
- [x] Added or updated tests / baselines
