### PR TITLE
no-duplicate-case: only use type information with strictNullChecks

### DIFF
--- a/baselines/packages/mimir/test/no-duplicate-case/project-loose/test.ts.lint
+++ b/baselines/packages/mimir/test/no-duplicate-case/project-loose/test.ts.lint
@@ -63,53 +63,36 @@ switch (foo) {
     case get<number | never>():
     case 1:
     case get<1>():
-         ~~~~~~~~  [error no-duplicate-case: Duplicate 'case 1'.]
     case +get<'1'>():
-         ~~~~~~~~~~~  [error no-duplicate-case: Duplicate 'case 1'.]
     case 'foo':
     case get<'foo'>():
-         ~~~~~~~~~~~~  [error no-duplicate-case: Duplicate 'case "foo"'.]
     case get<'foo' | 1>():
-         ~~~~~~~~~~~~~~~~  [error no-duplicate-case: Duplicate 'case "foo" | 1'.]
     case true:
     case !true:
     case get<true>():
-         ~~~~~~~~~~~  [error no-duplicate-case: Duplicate 'case true'.]
     case get<false>():
-         ~~~~~~~~~~~~  [error no-duplicate-case: Duplicate 'case false'.]
     case null:
     case undefined:
     case get<null>():
-         ~~~~~~~~~~~  [error no-duplicate-case: Duplicate 'case null'.]
     case get<void>():
     case get<undefined>():
-         ~~~~~~~~~~~~~~~~  [error no-duplicate-case: Duplicate 'case undefined'.]
     case E.Foo:
-         ~~~~~  [error no-duplicate-case: Duplicate 'case "foo"'.]
     case E.Bar:
     case E.Baz:
-         ~~~~~  [error no-duplicate-case: Duplicate 'case 1'.]
     case get<E>():
-         ~~~~~~~~  [error no-duplicate-case: Duplicate 'case "bar" | "foo" | 1'.]
     case get<E.Bar>():
-         ~~~~~~~~~~~~  [error no-duplicate-case: Duplicate 'case "bar"'.]
     case E2.Foo:
     case E2.Bar:
-         ~~~~~~  [error no-duplicate-case: Duplicate 'case 1'.]
     case E2.Baz:
     case 'a':
     case get<'a' | 'b'>():
     case 'b':
     case 'c':
     case get<'a' | 'b' | 'c'>():
-         ~~~~~~~~~~~~~~~~~~~~~~  [error no-duplicate-case: Duplicate 'case "a" | "b" | "c"'.]
     case get<'a' | boolean>():
-         ~~~~~~~~~~~~~~~~~~~~  [error no-duplicate-case: Duplicate 'case "a" | false | true'.]
     case get<'a' | number>():
     case +get<'1' | '1.0'>():
-         ~~~~~~~~~~~~~~~~~~~  [error no-duplicate-case: Duplicate 'case 1'.]
     case get<'a' | undefined>():
-         ~~~~~~~~~~~~~~~~~~~~~~  [error no-duplicate-case: Duplicate 'case "a"'.]
 }
 
 function test<T, U extends 1, V extends '1', W extends U | V>(param1: T, param2: U, param3: V, param4: W) {
@@ -118,8 +101,6 @@ function test<T, U extends 1, V extends '1', W extends U | V>(param1: T, param2:
         case param2:
         case param3:
         case +param3:
-             ~~~~~~~  [error no-duplicate-case: Duplicate 'case 1'.]
         case param4:
-             ~~~~~~  [error no-duplicate-case: Duplicate 'case "1" | 1'.]
     }
 }

--- a/packages/mimir/src/rules/no-duplicate-case.ts
+++ b/packages/mimir/src/rules/no-duplicate-case.ts
@@ -1,6 +1,6 @@
 import { AbstractRule, excludeDeclarationFiles } from '@fimbul/ymir';
 import * as ts from 'typescript';
-import { isTextualLiteral, isNumericLiteral, isPrefixUnaryExpression, isIdentifier, isLiteralType, unionTypeParts } from 'tsutils';
+import { isTextualLiteral, isNumericLiteral, isPrefixUnaryExpression, isIdentifier, isLiteralType, unionTypeParts, isStrictCompilerOptionEnabled } from 'tsutils';
 import { isBigIntLiteral } from 'tsutils/typeguard/3.2';
 import { switchStatements, formatPseudoBigInt } from '../utils';
 
@@ -66,7 +66,7 @@ export class Rule extends AbstractRule {
         if (node.kind === ts.SyntaxKind.FalseKeyword)
             return [formatPrimitive(prefixFn(false))];
 
-        if (this.program === undefined)
+        if (this.program === undefined || !isStrictCompilerOptionEnabled(this.program.getCompilerOptions(), 'strictNullChecks'))
             return [];
         const checker = this.program.getTypeChecker();
         let type = checker.getTypeAtLocation(node)!;

--- a/packages/mimir/src/rules/no-duplicate-case.ts
+++ b/packages/mimir/src/rules/no-duplicate-case.ts
@@ -1,6 +1,14 @@
 import { AbstractRule, excludeDeclarationFiles } from '@fimbul/ymir';
 import * as ts from 'typescript';
-import { isTextualLiteral, isNumericLiteral, isPrefixUnaryExpression, isIdentifier, isLiteralType, unionTypeParts, isStrictCompilerOptionEnabled } from 'tsutils';
+import {
+    isTextualLiteral,
+    isNumericLiteral,
+    isPrefixUnaryExpression,
+    isIdentifier,
+    isLiteralType,
+    unionTypeParts,
+    isStrictCompilerOptionEnabled,
+} from 'tsutils';
 import { isBigIntLiteral } from 'tsutils/typeguard/3.2';
 import { switchStatements, formatPseudoBigInt } from '../utils';
 


### PR DESCRIPTION
#### Checklist

- [x] Fixes: #459 
- [x] Added or updated tests / baselines

#### Overview of change 
Implicitly adding `null | undefined` to every type just made error reporting look kinda weird. Now we miss some errors in really rare cases, but the rule is not as confusing.