### PR TITLE
async-function-assignability: handle computed property names

### DIFF
--- a/baselines/packages/mimir/test/async-function-assignability/default/test.ts.lint
+++ b/baselines/packages/mimir/test/async-function-assignability/default/test.ts.lint
@@ -19,6 +19,11 @@ take(async () => {});
 take<any>(async () => {});
 take<() => any>(async () => {});
 
+take<(() => void) | undefined>(async () => {});
+                               ~~~~~            [error async-function-assignability: A 'Promise'-returning function should not be assigned to a 'void'-returning function type.]
+take<(() => void) | undefined>(get<(() => Promise<void>) | undefined>());
+                               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~   [error async-function-assignability: A 'Promise'-returning function should not be assigned to a 'void'-returning function type.]
+
 take<() => void>(async function foo() {});
                  ~~~~~                     [error async-function-assignability: A 'Promise'-returning function should not be assigned to a 'void'-returning function type.]
 take<() => void>(function foo() { return Promise.resolve(); });
@@ -32,16 +37,26 @@ take<() => void>(function() { return Promise.resolve(); });
 const foo = {async foo() {}};
 take({async foo() {}});
 take<{foo?: () => void}>({async foo() {}});
-                          ~~~~~             [error async-function-assignability: A 'Promise'-returning function should not be assigned to a 'void'-returning function type.]
+                          ~~~~~             [error async-function-assignability: 'Promise'-returning method 'foo' should not be assigned to a 'void'-returning function type.]
 take<{foo: () => void}>({foo() { return Promise.resolve(); }});
-                         ~~~                                    [error async-function-assignability: A 'Promise'-returning function should not be assigned to a 'void'-returning function type.]
+                         ~~~                                    [error async-function-assignability: 'Promise'-returning method 'foo' should not be assigned to a 'void'-returning function type.]
 take<{foo: () => void}>({foo() {}});
 take<{foo: () => void}>({async [get<'foo'>()]() {}});
+                         ~~~~~                        [error async-function-assignability: 'Promise'-returning method 'foo' should not be assigned to a 'void'-returning function type.]
 take<{[x: string]: () => void}>({async foo() {}, async '1'() {}});
-                                 ~~~~~                             [error async-function-assignability: A 'Promise'-returning function should not be assigned to a 'void'-returning function type.]
-                                                 ~~~~~             [error async-function-assignability: A 'Promise'-returning function should not be assigned to a 'void'-returning function type.]
+                                 ~~~~~                             [error async-function-assignability: 'Promise'-returning method 'foo' should not be assigned to a 'void'-returning function type.]
+                                                 ~~~~~             [error async-function-assignability: 'Promise'-returning method '1' should not be assigned to a 'void'-returning function type.]
 take<{[x: string]: () => void; [x: number]: () => PromiseLike<void>}>({async foo() {}, async '1'() {}});
-                                                                       ~~~~~                             [error async-function-assignability: A 'Promise'-returning function should not be assigned to a 'void'-returning function type.]
+                                                                       ~~~~~                             [error async-function-assignability: 'Promise'-returning method 'foo' should not be assigned to a 'void'-returning function type.]
+
+const name = 'foo';
+take<{foo: () => void}>({async [name]() {}});
+                         ~~~~~                [error async-function-assignability: 'Promise'-returning method 'foo' should not be assigned to a 'void'-returning function type.]
+take<{[x: string]: (() => void) | undefined; bar?: () => Promise<void>}>({async [get<'foo' | 'bar'>()]() {}});
+                                                                          ~~~~~                                [error async-function-assignability: 'Promise'-returning method 'foo' should not be assigned to a 'void'-returning function type.]
+take<{[x: string]: (() => void) | undefined}>({async [get<'foo' | 'bar'>()]() {}});
+                                               ~~~~~                                [error async-function-assignability: 'Promise'-returning method 'foo' should not be assigned to a 'void'-returning function type.]
+take<{[x: string]: (() => Promise<void>) | undefined}>({async [get<'foo' | 'bar'>()]() {}});
 
 declare class C<T> {
     foo(): T;
@@ -57,43 +72,68 @@ declare interface I<T> {
 
 class D extends C<void> implements I<void> {
     async foo() {}
-    ~~~~~          [error async-function-assignability: Overriding 'void'-returning method in base type with a 'Promise'-returning method is unsafe.]
+    ~~~~~          [error async-function-assignability: Overriding 'void'-returning method 'foo' of base type with a 'Promise'-returning method is unsafe.]
     baz = async () => {};
-    ~~~                   [error async-function-assignability: Overriding 'void'-returning method in base type with a 'Promise'-returning method is unsafe.]
+    ~~~                   [error async-function-assignability: Overriding 'void'-returning method 'baz' of base type with a 'Promise'-returning method is unsafe.]
     bas() {}
 }
 
+const otherName = 'overloaded';
+(class extends C<void> {
+    async [name]() {}
+    ~~~~~             [error async-function-assignability: Overriding 'void'-returning method 'foo' of base type with a 'Promise'-returning method is unsafe.]
+    [otherName](): void;
+    [otherName](foo?: boolean): Promise<void>;
+    ~~~~~~~~~~~                                [error async-function-assignability: Overriding 'void'-returning method 'overloaded' of base type with a 'Promise'-returning method is unsafe.]
+    async [otherName]() {}
+    ~~~~~                  [error async-function-assignability: Overriding 'void'-returning method 'overloaded' of base type with a 'Promise'-returning method is unsafe.]
+});
+
+(class extends C<void> {
+    [name]: () => Promise<void>;
+    ~~~~~~                       [error async-function-assignability: Overriding 'void'-returning method 'foo' of base type with a 'Promise'-returning method is unsafe.]
+    [otherName]: () => void;
+});
+
 (class extends C<void> implements I<void>{
     async foo() {}
-    ~~~~~          [error async-function-assignability: Overriding 'void'-returning method in base type with a 'Promise'-returning method is unsafe.]
+    ~~~~~          [error async-function-assignability: Overriding 'void'-returning method 'foo' of base type with a 'Promise'-returning method is unsafe.]
     async bar() {}
     baz() {
-    ~~~     [error async-function-assignability: Overriding 'void'-returning method in base type with a 'Promise'-returning method is unsafe.]
+    ~~~     [error async-function-assignability: Overriding 'void'-returning method 'baz' of base type with a 'Promise'-returning method is unsafe.]
         return Promise.resolve();
     }
     async [get<'bas'>()]() {}
+    ~~~~~                     [error async-function-assignability: Overriding 'void'-returning method 'bas' of base type with a 'Promise'-returning method is unsafe.]
+    async bas() {}
+    ~~~~~          [error async-function-assignability: Overriding 'void'-returning method 'bas' of base type with a 'Promise'-returning method is unsafe.]
 
     async overloaded(): Promise<void>;
-    ~~~~~                              [error async-function-assignability: Overriding 'void'-returning method in base type with a 'Promise'-returning method is unsafe.]
+    ~~~~~                              [error async-function-assignability: Overriding 'void'-returning method 'overloaded' of base type with a 'Promise'-returning method is unsafe.]
     async overloaded(param: string): Promise<void>;
-    ~~~~~                                           [error async-function-assignability: Overriding 'void'-returning method in base type with a 'Promise'-returning method is unsafe.]
+    ~~~~~                                           [error async-function-assignability: Overriding 'void'-returning method 'overloaded' of base type with a 'Promise'-returning method is unsafe.]
     async overloaded() {
-    ~~~~~                [error async-function-assignability: Overriding 'void'-returning method in base type with a 'Promise'-returning method is unsafe.]
+    ~~~~~                [error async-function-assignability: Overriding 'void'-returning method 'overloaded' of base type with a 'Promise'-returning method is unsafe.]
         return;
     }
 });
 
 (class implements C<void> {
     async foo() {}
-    ~~~~~          [error async-function-assignability: Overriding 'void'-returning method in base type with a 'Promise'-returning method is unsafe.]
+    ~~~~~          [error async-function-assignability: Overriding 'void'-returning method 'foo' of base type with a 'Promise'-returning method is unsafe.]
     async bar() {}
     async baz() {}
+    overloaded(): void;
+    overloaded(foo?: boolean): Promise<void>;
+    ~~~~~~~~~~                                [error async-function-assignability: Overriding 'void'-returning method 'overloaded' of base type with a 'Promise'-returning method is unsafe.]
+    async overloaded(foo?: boolean) {}
+    ~~~~~                              [error async-function-assignability: Overriding 'void'-returning method 'overloaded' of base type with a 'Promise'-returning method is unsafe.]
 });
 
 (class implements I<void> {
     async foo() {}
     async bar() {}
     async baz() {}
-    ~~~~~          [error async-function-assignability: Overriding 'void'-returning method in base type with a 'Promise'-returning method is unsafe.]
+    ~~~~~          [error async-function-assignability: Overriding 'void'-returning method 'baz' of base type with a 'Promise'-returning method is unsafe.]
     bas() {}
 });

--- a/packages/mimir/test/async-function-assignability/test.ts
+++ b/packages/mimir/test/async-function-assignability/test.ts
@@ -13,6 +13,9 @@ take(async () => {});
 take<any>(async () => {});
 take<() => any>(async () => {});
 
+take<(() => void) | undefined>(async () => {});
+take<(() => void) | undefined>(get<(() => Promise<void>) | undefined>());
+
 take<() => void>(async function foo() {});
 take<() => void>(function foo() { return Promise.resolve(); });
 take<() => void>(function() { return Promise.resolve(); });
@@ -27,6 +30,12 @@ take<{foo: () => void}>({foo() {}});
 take<{foo: () => void}>({async [get<'foo'>()]() {}});
 take<{[x: string]: () => void}>({async foo() {}, async '1'() {}});
 take<{[x: string]: () => void; [x: number]: () => PromiseLike<void>}>({async foo() {}, async '1'() {}});
+
+const name = 'foo';
+take<{foo: () => void}>({async [name]() {}});
+take<{[x: string]: (() => void) | undefined; bar?: () => Promise<void>}>({async [get<'foo' | 'bar'>()]() {}});
+take<{[x: string]: (() => void) | undefined}>({async [get<'foo' | 'bar'>()]() {}});
+take<{[x: string]: (() => Promise<void>) | undefined}>({async [get<'foo' | 'bar'>()]() {}});
 
 declare class C<T> {
     foo(): T;
@@ -46,6 +55,19 @@ class D extends C<void> implements I<void> {
     bas() {}
 }
 
+const otherName = 'overloaded';
+(class extends C<void> {
+    async [name]() {}
+    [otherName](): void;
+    [otherName](foo?: boolean): Promise<void>;
+    async [otherName]() {}
+});
+
+(class extends C<void> {
+    [name]: () => Promise<void>;
+    [otherName]: () => void;
+});
+
 (class extends C<void> implements I<void>{
     async foo() {}
     async bar() {}
@@ -53,6 +75,7 @@ class D extends C<void> implements I<void> {
         return Promise.resolve();
     }
     async [get<'bas'>()]() {}
+    async bas() {}
 
     async overloaded(): Promise<void>;
     async overloaded(param: string): Promise<void>;
@@ -65,6 +88,9 @@ class D extends C<void> implements I<void> {
     async foo() {}
     async bar() {}
     async baz() {}
+    overloaded(): void;
+    overloaded(foo?: boolean): Promise<void>;
+    async overloaded(foo?: boolean) {}
 });
 
 (class implements I<void> {


### PR DESCRIPTION
#### Checklist

- [x] Fixes: #468 
- [x] Added or updated tests / baselines

#### Overview of change 
* handle computed names
* include property or method name in message text.
* handle overload signatures separately
* remove `| undefined` before looking for call signatures