### PR TITLE
avoid uses of require where possible

### DIFF
--- a/packages/heimdall/src/index.ts
+++ b/packages/heimdall/src/index.ts
@@ -29,8 +29,8 @@ export class TslintFormatterLoaderHost extends NodeFormatterLoader {
 
 @injectable()
 export class TslintRuleLoaderHost extends NodeRuleLoader {
-    constructor(resolver: BuiltinResolver) {
-        super(resolver);
+    constructor(builtinResolver: BuiltinResolver, resolver: Resolver) {
+        super(builtinResolver, resolver);
     }
 
     public loadCustomRule(name: string, dir: string): RuleConstructor | undefined {

--- a/packages/heimdall/test/formatter-loader.spec.ts
+++ b/packages/heimdall/test/formatter-loader.spec.ts
@@ -11,6 +11,9 @@ test('loads TSLint formatter if no wotan formatter is found', (t) => {
         }
     }
     const resolver: Resolver = {
+        getDefaultExtensions() {
+            return [];
+        },
         resolve() {
             return 'foo';
         },

--- a/packages/heimdall/test/rule-loader.spec.ts
+++ b/packages/heimdall/test/rule-loader.spec.ts
@@ -1,13 +1,27 @@
 import test from 'ava';
 import { TslintRuleLoaderHost } from '../src';
 import * as path from 'path';
+import {
+    NodeResolver,
+    CachedFileSystem,
+    NodeFileSystem,
+    ConsoleMessageHandler,
+    DefaultCacheFactory,
+    NodeDirectoryService,
+} from '@fimbul/wotan';
 
 test('loads TSLint rule as custom rule if no wotan rule is found', (t) => {
-    const loader = new TslintRuleLoaderHost({
-        resolveConfig() { throw new Error(); },
-        resolveFormatter() { throw new Error(); },
-        resolveRule(name) { return path.join(__dirname, '../../mimir/src/rules', name + '.js'); },
-    });
+    const loader = new TslintRuleLoaderHost(
+        {
+            resolveConfig() { throw new Error(); },
+            resolveFormatter() { throw new Error(); },
+            resolveRule(name) { return path.join(__dirname, '../../mimir/src/rules', name + '.js'); },
+        },
+        new NodeResolver(
+            new CachedFileSystem(new NodeFileSystem(new ConsoleMessageHandler()), new DefaultCacheFactory()),
+            new NodeDirectoryService(),
+        ),
+    );
     t.is(loader.loadCustomRule('my-rule', path.resolve('packages/heimdall/test/fixtures')), require('./fixtures/my-rule').Rule);
     t.not(loader.loadCustomRule('semicolon', '/'), undefined);
     t.not(loader.loadCustomRule('my-tslint-rule', path.resolve('packages/heimdall/test/fixtures')), undefined);

--- a/packages/valtyr/src/configuration-provider.ts
+++ b/packages/valtyr/src/configuration-provider.ts
@@ -58,7 +58,7 @@ export class TslintConfigurationProvider implements ConfigurationProvider {
     }
 
     public resolve(name: string, basedir: string) {
-        const extensions = Object.keys(require.extensions).filter((e) => e !== '.node');
+        const extensions = [...this.resolver.getDefaultExtensions(), '.json'];
         if (name.startsWith('tslint:')) {
             try {
                 if (this.tslintConfigDir === undefined)

--- a/packages/wotan/src/services/configuration-manager.ts
+++ b/packages/wotan/src/services/configuration-manager.ts
@@ -89,7 +89,7 @@ export class ConfigurationManager {
         return reduceSettings(config, path.resolve(this.directories.getCurrentDirectory(), fileName), new Map());
     }
 
-    /** Load a configuration from the specified file using the ConfigurationProvider, recursively resolving and loading base configs. */
+    /** Load a configuration from a resolved path using the ConfigurationProvider, recursively resolving and loading base configs. */
     public load(fileName: string): Configuration {
         const stack: string[] = [];
         const loadResolved = (file: string): Configuration => {

--- a/packages/wotan/src/services/default/builtin-resolver.ts
+++ b/packages/wotan/src/services/default/builtin-resolver.ts
@@ -1,13 +1,12 @@
 import { injectable } from 'inversify';
 import { BuiltinResolver, Resolver } from '@fimbul/ymir';
 import * as path from 'path';
-import { OFFSET_TO_NODE_MODULES } from '../../utils';
 
 @injectable()
 export class DefaultBuiltinResolver implements BuiltinResolver {
     private get builtinPackagePath() {
         const resolved = path.dirname(
-            this.resolver.resolve('@fimbul/mimir', path.join(__dirname, '../'.repeat(OFFSET_TO_NODE_MODULES)), []),
+            this.resolver.resolve('@fimbul/mimir', path.join(__dirname, '../'.repeat(/*offset to package root*/ 3)), []),
         );
         Object.defineProperty(this, 'builtinPackagePath', {value: resolved});
 

--- a/packages/wotan/src/services/default/configuration-provider.ts
+++ b/packages/wotan/src/services/default/configuration-provider.ts
@@ -176,7 +176,7 @@ export class DefaultConfigurationProvider implements ConfigurationProvider {
         return processor && this.resolver.resolve(
             processor,
             basedir,
-            Object.keys(require.extensions).filter((ext) => ext !== '.json' && ext !== '.node'),
+            undefined,
             module.paths.slice(OFFSET_TO_NODE_MODULES + 2),
         );
     }

--- a/packages/wotan/src/services/default/formatter-loader-host.ts
+++ b/packages/wotan/src/services/default/formatter-loader-host.ts
@@ -9,25 +9,18 @@ export class NodeFormatterLoader implements FormatterLoaderHost {
     public loadCoreFormatter(name: string): FormatterConstructor | undefined {
         name = this.builtinResolver.resolveFormatter(name);
         try {
-            return require(name).Formatter;
-        } catch (e) {
-            if (e != undefined && e.code === 'MODULE_NOT_FOUND' && e.message === `Cannot find module '${name}'`)
-                return;
-            throw e;
-        }
-    }
-    public loadCustomFormatter(name: string, basedir: string): FormatterConstructor | undefined {
-        let resolved: string;
-        try {
-            resolved = this.resolver.resolve(
-                name,
-                basedir,
-                Object.keys(require.extensions).filter((ext) => ext !== '.json' && ext !== '.node'),
-                module.paths.slice(OFFSET_TO_NODE_MODULES + 1),
-            );
+            name = this.resolver.resolve(name);
         } catch {
             return;
         }
-        return this.resolver.require(resolved).Formatter;
+        return this.resolver.require(name).Formatter;
+    }
+    public loadCustomFormatter(name: string, basedir: string): FormatterConstructor | undefined {
+        try {
+            name = this.resolver.resolve(name, basedir, undefined, module.paths.slice(OFFSET_TO_NODE_MODULES + 2));
+        } catch {
+            return;
+        }
+        return this.resolver.require(name).Formatter;
     }
 }

--- a/packages/wotan/src/services/default/resolver.ts
+++ b/packages/wotan/src/services/default/resolver.ts
@@ -1,13 +1,24 @@
 import { injectable } from 'inversify';
-import { Resolver } from '@fimbul/ymir';
+import { Resolver, DirectoryService } from '@fimbul/ymir';
 import { CachedFileSystem } from '../cached-file-system';
 import * as resolve from 'resolve';
 
 @injectable()
 export class NodeResolver implements Resolver {
-    constructor(private fs: CachedFileSystem) {}
+    private defaultExtensions: ReadonlyArray<string> = Object.keys(require.extensions).filter((ext) => ext !== '.json' && ext !== '.node');
 
-    public resolve(id: string, basedir: string, extensions: ReadonlyArray<string>, paths?: ReadonlyArray<string>): string {
+    constructor(private fs: CachedFileSystem, private directories: DirectoryService) {}
+
+    public getDefaultExtensions() {
+        return this.defaultExtensions;
+    }
+
+    public resolve(
+        id: string,
+        basedir = this.directories.getCurrentDirectory(),
+        extensions = this.defaultExtensions,
+        paths?: ReadonlyArray<string>,
+    ): string {
         return resolve.sync(id, {
             basedir,
             extensions,

--- a/packages/wotan/src/services/processor-loader.ts
+++ b/packages/wotan/src/services/processor-loader.ts
@@ -1,7 +1,6 @@
 import { ProcessorConstructor, Resolver, CacheFactory, Cache, ConfigurationError } from '@fimbul/ymir';
 import { injectable } from 'inversify';
 import { resolveCachedResult } from '../utils';
-import bind from 'bind-decorator';
 
 @injectable()
 export class ProcessorLoader {
@@ -11,20 +10,11 @@ export class ProcessorLoader {
     }
 
     public loadProcessor(path: string): ProcessorConstructor {
-        return resolveCachedResult(this.cache, path, this.requireProcessor);
-    }
-
-    @bind
-    private requireProcessor(path: string): ProcessorConstructor {
-        try {
-            const result = this.resolver.require(path).Processor;
+        return resolveCachedResult(this.cache, path, (p) => {
+            const result = this.resolver.require(p).Processor;
             if (result === undefined)
-                throw new ConfigurationError(`'${path}' has no export named 'Processor'.`);
+                throw new ConfigurationError(`'${p}' has no export named 'Processor'.`);
             return result;
-        } catch (e) {
-            if (e != undefined && e.code === 'MODULE_NOT_FOUND' && e.message === `Cannot find module '${path}'`)
-                throw new ConfigurationError(e.message);
-            throw e;
-        }
+        });
     }
 }

--- a/packages/wotan/test/configuration.spec.ts
+++ b/packages/wotan/test/configuration.spec.ts
@@ -12,6 +12,7 @@ import {
     LoadConfigurationContext,
     ConfigurationError,
     BuiltinResolver,
+    DirectoryService,
 } from '@fimbul/ymir';
 import { Container, injectable } from 'inversify';
 import { CachedFileSystem } from '../src/services/cached-file-system';
@@ -26,6 +27,7 @@ import { ConsoleMessageHandler } from '../src/services/default/message-handler';
 import { createCoreModule } from '../src/di/core.module';
 import { createDefaultModule } from '../src/di/default.module';
 import { DefaultBuiltinResolver } from '../src/services/default/builtin-resolver';
+import { NodeDirectoryService } from '../src/services/default/directory-service';
 
 // tslint:disable:no-null-keyword
 
@@ -246,6 +248,7 @@ test('DefaultConfigurationProvider.find', (t) => {
     container.bind(CacheFactory).to(DefaultCacheFactory);
     container.bind(Resolver).to(NodeResolver);
     container.bind(BuiltinResolver).to(DefaultBuiltinResolver);
+    container.bind(DirectoryService).to(NodeDirectoryService);
 
     const cwd = path.join(path.parse(process.cwd()).root, 'some/project/directory');
 
@@ -344,6 +347,7 @@ test('DefaultConfigurationProvider.resolve', (t) => {
     container.bind(Resolver).to(NodeResolver);
     container.bind(FileSystem).to(NodeFileSystem);
     container.bind(MessageHandler).to(ConsoleMessageHandler);
+    container.bind(DirectoryService).to(NodeDirectoryService);
     const builtinResolver: BuiltinResolver = {
         resolveConfig(name) { return path.join(__dirname, '../../mimir', name + '.yaml'); },
         resolveFormatter() { throw new Error(); },
@@ -367,6 +371,9 @@ test('DefaultConfigurationProvider.read', (t) => {
 
     const empty = {};
     const resolver: Resolver = {
+        getDefaultExtensions() {
+            return [];
+        },
         resolve() {
             return '';
         },
@@ -428,6 +435,7 @@ test('ConfigurationProvider.parse', (t) => {
     container.bind(FileSystem).to(NodeFileSystem);
     container.bind(MessageHandler).to(ConsoleMessageHandler);
     container.bind(BuiltinResolver).to(DefaultBuiltinResolver);
+    container.bind(DirectoryService).to(NodeDirectoryService);
 
     const cp = container.resolve(DefaultConfigurationProvider);
     const mockContext: LoadConfigurationContext = {

--- a/packages/wotan/test/services.spec.ts
+++ b/packages/wotan/test/services.spec.ts
@@ -79,7 +79,13 @@ test('RuleLoaderHost', (t) => {
             return path.join(__dirname, '../../mimir/src/rules', name + '.js');
         },
     };
-    const loader = new NodeRuleLoader(builtinResolver);
+    const loader = new NodeRuleLoader(
+        builtinResolver,
+        new NodeResolver(
+            new CachedFileSystem(new NodeFileSystem(new ConsoleMessageHandler()), new DefaultCacheFactory()),
+            new NodeDirectoryService(),
+        ),
+    );
     t.is(loader.loadCoreRule('no-debugger'), Rule);
     t.is(loader.loadCoreRule('fooBarBaz'), undefined);
     builtinResolver.resolveRule = (name) => path.join(__dirname, 'fixtures', name + '.js');
@@ -171,6 +177,7 @@ test('Resolver', (t) => {
     container.bind(MessageHandler).to(ConsoleMessageHandler);
     container.bind(CachedFileSystem).toSelf();
     container.bind(CacheFactory).to(DefaultCacheFactory);
+    container.bind(DirectoryService).to(NodeDirectoryService);
     const resolver = container.resolve(NodeResolver);
     t.is(resolver.resolve('tslib', process.cwd(), ['.js']), require.resolve('tslib'));
     t.is(resolver.resolve('tslib', '/', ['.js'], module.paths), require.resolve('tslib'));
@@ -191,6 +198,7 @@ test('FormatterLoaderHost', (t) => {
     container.bind(CachedFileSystem).toSelf();
     container.bind(CacheFactory).to(DefaultCacheFactory);
     container.bind(Resolver).to(NodeResolver);
+    container.bind(DirectoryService).to(NodeDirectoryService);
     const builtinResolver: BuiltinResolver = {
         resolveConfig() { throw new Error(); },
         resolveRule() { throw new Error(); },
@@ -392,6 +400,9 @@ test.after.always(() => {
 test('ProcessorLoader', (t) => {
     let r: (id: string) => any;
     const resolver: Resolver = {
+        getDefaultExtensions() {
+            return [];
+        },
         resolve(): never {
             throw new Error('should not be called');
         },
@@ -415,7 +426,5 @@ test('ProcessorLoader', (t) => {
     r = () => ({});
     t.throws(() => loader.loadProcessor('bar'), "'bar' has no export named 'Processor'.");
     r = require;
-    t.throws(() => loader.loadProcessor('./fooBarBaz'), (err) => {
-        return (err instanceof ConfigurationError) && /Cannot find module '\.\/fooBarBaz'/.test(err.message);
-    });
+    t.throws(() => loader.loadProcessor('./fooBarBaz'), "Cannot find module './fooBarBaz'");
 });

--- a/packages/ymir/src/index.ts
+++ b/packages/ymir/src/index.ts
@@ -427,7 +427,8 @@ export interface Cache<K, V> {
 }
 
 export interface Resolver {
-    resolve(id: string, basedir: string, extensions: ReadonlyArray<string>, paths?: ReadonlyArray<string>): string;
+    getDefaultExtensions(): ReadonlyArray<string>;
+    resolve(id: string, basedir?: string, extensions?: ReadonlyArray<string>, paths?: ReadonlyArray<string>): string;
     require(id: string, options?: {cache?: boolean}): any;
 }
 export abstract class Resolver {}


### PR DESCRIPTION
#### Checklist

- [x] Required for: #408 
- [x] Added or updated tests / baselines

#### Overview of change 
Move all uses of `require` to `NodeResolver`. This allows for easy substitution by only providing one different service.
It also removes code that relied on Node's module not found errors.