### PR TITLE
ve: trim off leading line break

### DIFF
--- a/packages/valtyr/test/fixtures/processed2.vue
+++ b/packages/valtyr/test/fixtures/processed2.vue
@@ -1,0 +1,6 @@
+<template>
+    <input type="text">
+</template>
+<script lang="ts">import Vue from "vue"; export default Vue.extend({});</script>
+<style>
+</style>

--- a/packages/valtyr/test/fixtures/processed2.vue
+++ b/packages/valtyr/test/fixtures/processed2.vue
@@ -1,6 +1,8 @@
 <template>
     <input type="text">
 </template>
-<script lang="ts">import Vue from "vue"; export default Vue.extend({});</script>
+<script lang="ts">import Vue from "vue"; export default Vue.extend({});
+let foo = 'bar';
+</script>
 <style>
 </style>

--- a/packages/valtyr/test/fixtures/processed3.vue
+++ b/packages/valtyr/test/fixtures/processed3.vue
@@ -1,0 +1,1 @@
+<script lang="ts">import Vue from "vue"; export default Vue.extend({});</script>

--- a/packages/valtyr/test/module.spec.ts
+++ b/packages/valtyr/test/module.spec.ts
@@ -37,6 +37,7 @@ test('load processor config from .fimbullinter.yaml', async (t) => {
     t.is(result.stdout.trim(), `ERROR: ${resolve('processed.vue')}[5, 1]: test message
 WARNING: ${resolve('processed.vue')}[5, 17]: ' should be "
 ERROR: ${resolve('processed2.vue')}[4, 19]: test message
+WARNING: ${resolve('processed2.vue')}[5, 11]: ' should be "
 ERROR: ${resolve('processed3.vue')}[1, 19]: test message`);
 });
 

--- a/packages/valtyr/test/module.spec.ts
+++ b/packages/valtyr/test/module.spec.ts
@@ -34,8 +34,10 @@ test('load processor config from .fimbullinter.yaml', async (t) => {
     const result = await execCli(['-m', '../..', '-f', 'prose', '*.vue'], 'packages/valtyr/test/fixtures');
     t.is(result.stderr, '');
     t.is(result.code, 2);
-    t.is(result.stdout.trim(), `ERROR: ${resolve('processed.vue')}[4, 19]: test message
-WARNING: ${resolve('processed.vue')}[5, 17]: ' should be "`);
+    t.is(result.stdout.trim(), `ERROR: ${resolve('processed.vue')}[5, 1]: test message
+WARNING: ${resolve('processed.vue')}[5, 17]: ' should be "
+ERROR: ${resolve('processed2.vue')}[4, 19]: test message
+ERROR: ${resolve('processed3.vue')}[1, 19]: test message`);
 });
 
 function resolve(p: string) {


### PR DESCRIPTION
#### Checklist

- [x] Fixes an issue reported by @romansp on Gitter
- [x] Added or updated tests / baselines

#### Overview of change 
Don't include the line break following the opening tag in the linted source code.
Also fixes an outstanding TODO to adjust the character offset if there is no line break after the opening tag