### PR TITLE
configuration: patterns match dotfiles

### DIFF
--- a/packages/valtyr/src/configuration-provider.ts
+++ b/packages/valtyr/src/configuration-provider.ts
@@ -88,12 +88,12 @@ export class TslintConfigurationProvider implements ConfigurationProvider {
         const overrides: Configuration.Override[] = [];
         if (raw.rules.size !== 0)
             overrides.push({
-                files: ['*', '.*', '!*.js?(x)'],
+                files: ['*', '!*.js?(x)'],
                 rules: new Map(Array.from(raw.rules, mapRules)),
             });
         if (raw.jsRules.size !== 0)
             overrides.push({
-                files: ['*.js?(x)', '.*.js?(x)'],
+                files: ['*.js?(x)'],
                 rules: new Map(Array.from(raw.jsRules, mapRules)),
             });
         return {

--- a/packages/valtyr/test/configuration-provider.spec.ts
+++ b/packages/valtyr/test/configuration-provider.spec.ts
@@ -59,7 +59,7 @@ test('parse', (t) => {
             exclude: undefined,
             overrides: [
                 {
-                    files: ['*', '.*', '!*.js?(x)'],
+                    files: ['*', '!*.js?(x)'],
                     rules: new Map<string, Configuration.RuleConfig>([
                         ['foo', {rule: 'foo', options: undefined, rulesDirectories: undefined, severity: 'error'}],
                         ['bar', {rule: 'bar', options: ['test'], rulesDirectories: undefined, severity: 'off'}],
@@ -88,7 +88,7 @@ test('parse', (t) => {
             exclude: undefined,
             overrides: [
                 {
-                    files: ['*.js?(x)', '.*.js?(x)'],
+                    files: ['*.js?(x)'],
                     rules: new Map<string, Configuration.RuleConfig>([
                         ['foo', {rule: 'foo', options: undefined, rulesDirectories: ['/foo'], severity: 'error'}],
                         ['bar', {rule: 'bar', options: ['test'], rulesDirectories: ['/foo'], severity: 'off'}],

--- a/packages/wotan/README.md
+++ b/packages/wotan/README.md
@@ -92,8 +92,10 @@ overrides:
 
 Overrides are processed in order and applied in order. The latter one overrides all prior overrides.
 
-Note that in the example above `*.spec.ts` matches in all directories. Normally patterns are matched relative to the configuration file they are specified in. Patterns without any slash are treated special. These will only be matched against the basename of every file in every directory.
+Note that in the example above `*.spec.ts` matches in all directories. Normally patterns are matched relative to the configuration file they are specified in. Patterns without any slash are treated special. They will only be matched against the basename of every file in every directory.
 If you want to limit the pattern to the current directory, you can prefix it with `./` resulting in `./*.spec.ts`.
+
+`*` also matches the leading do if present, so you don't need a second glob pattern for dotfiles. That means `*.spec.ts` matches `.some.spec.ts` as well as `some.spec.ts`.
 
 ### Configuring Rules
 

--- a/packages/wotan/src/services/configuration-manager.ts
+++ b/packages/wotan/src/services/configuration-manager.ts
@@ -145,7 +145,7 @@ function matchesGlobs(file: string, patterns: ReadonlyArray<string>): boolean {
         const local = glob.pattern.startsWith('./');
         if (local)
             glob.pattern = glob.pattern.substr(2);
-        if (new Minimatch(glob.pattern, {matchBase: !local}).match(file))
+        if (new Minimatch(glob.pattern, {matchBase: !local, dot: true}).match(file))
             return !glob.negated;
     }
     return false;


### PR DESCRIPTION
#### Checklist

- [x] Added or updated tests / baselines
- [x] Documentation update

#### Overview of change 

Changes glob patterns in `processor.files` and `exclude` to match dotfiles by default.