### PR TITLE
no-useless-predicate: treat index signature as optional

### DIFF
--- a/baselines/packages/mimir/test/no-useless-predicate/default/test.ts.lint
+++ b/baselines/packages/mimir/test/no-useless-predicate/default/test.ts.lint
@@ -266,3 +266,44 @@ typeof 1 === TypeOf.String;
 ~~~~~~~~~~~~~~~~~~~~~~~~~~  [error no-useless-predicate: Expression is always falsy.]
 
 typeof true === get<TypeOf>();
+
+declare let arr: Array<true>;
+typeof arr[0] === 'boolean';
+typeof arr[0] === 'undefined';
+typeof arr[0] === 'number';
+~~~~~~~~~~~~~~~~~~~~~~~~~~  [error no-useless-predicate: Expression is always falsy.]
+!arr[0];
+arr[0] === undefined;
+!arr.length;
+!arr['length'];
+!arr[Symbol.iterator];
+ ~~~~~~~~~~~~~~~~~~~~  [error no-useless-predicate: Expression is always truthy.]
+
+declare let tuple: [Date];
+typeof tuple[0] === 'object';
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~  [error no-useless-predicate: Expression is always truthy.]
+typeof tuple[0] === 'undefined';
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  [error no-useless-predicate: Expression is always falsy.]
+typeof tuple[0] === 'number';
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~  [error no-useless-predicate: Expression is always falsy.]
+!tuple[0];
+ ~~~~~~~~  [error no-useless-predicate: Expression is always truthy.]
+tuple[0] === undefined;
+~~~~~~~~~~~~~~~~~~~~~~  [error no-useless-predicate: Expression is always falsy.]
+!tuple.length;
+ ~~~~~~~~~~~~  [error no-useless-predicate: Expression is always truthy.]
+!tuple['length'];
+ ~~~~~~~~~~~~~~~  [error no-useless-predicate: Expression is always truthy.]
+
+declare let indexer: { [s: string]: true; foo: true; bar: true };
+!indexer.foo;
+ ~~~~~~~~~~~  [error no-useless-predicate: Expression is always truthy.]
+!indexer.bar;
+ ~~~~~~~~~~~  [error no-useless-predicate: Expression is always truthy.]
+!indexer.baz;
+!indexer[get<'foo'>()];
+ ~~~~~~~~~~~~~~~~~~~~~  [error no-useless-predicate: Expression is always truthy.]
+!indexer[get<'foo' | 'bar'>()];
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  [error no-useless-predicate: Expression is always truthy.]
+!indexer[get<'foo' | 'baz'>()];
+!indexer[get<string>()];

--- a/baselines/packages/mimir/test/no-useless-predicate/loose/test.ts.lint
+++ b/baselines/packages/mimir/test/no-useless-predicate/loose/test.ts.lint
@@ -229,3 +229,45 @@ typeof 1 === TypeOf.String;
 ~~~~~~~~~~~~~~~~~~~~~~~~~~  [error no-useless-predicate: Expression is always falsy.]
 
 typeof true === get<TypeOf>();
+
+declare let arr: Array<true>;
+typeof arr[0] === 'boolean';
+typeof arr[0] === 'undefined';
+typeof arr[0] === 'number';
+~~~~~~~~~~~~~~~~~~~~~~~~~~  [error no-useless-predicate: Expression is always falsy.]
+!arr[0];
+ ~~~~~~  [error no-useless-predicate: Expression is always truthy.]
+arr[0] === undefined;
+!arr.length;
+!arr['length'];
+!arr[Symbol.iterator];
+ ~~~~~~~~~~~~~~~~~~~~  [error no-useless-predicate: Expression is always truthy.]
+
+declare let tuple: [Date];
+typeof tuple[0] === 'object';
+typeof tuple[0] === 'undefined';
+typeof tuple[0] === 'number';
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~  [error no-useless-predicate: Expression is always falsy.]
+!tuple[0];
+ ~~~~~~~~  [error no-useless-predicate: Expression is always truthy.]
+tuple[0] === undefined;
+!tuple.length;
+ ~~~~~~~~~~~~  [error no-useless-predicate: Expression is always truthy.]
+!tuple['length'];
+ ~~~~~~~~~~~~~~~  [error no-useless-predicate: Expression is always truthy.]
+
+declare let indexer: { [s: string]: true; foo: true; bar: true };
+!indexer.foo;
+ ~~~~~~~~~~~  [error no-useless-predicate: Expression is always truthy.]
+!indexer.bar;
+ ~~~~~~~~~~~  [error no-useless-predicate: Expression is always truthy.]
+!indexer.baz;
+ ~~~~~~~~~~~  [error no-useless-predicate: Expression is always truthy.]
+!indexer[get<'foo'>()];
+ ~~~~~~~~~~~~~~~~~~~~~  [error no-useless-predicate: Expression is always truthy.]
+!indexer[get<'foo' | 'bar'>()];
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  [error no-useless-predicate: Expression is always truthy.]
+!indexer[get<'foo' | 'baz'>()];
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  [error no-useless-predicate: Expression is always truthy.]
+!indexer[get<string>()];
+ ~~~~~~~~~~~~~~~~~~~~~~  [error no-useless-predicate: Expression is always truthy.]

--- a/baselines/packages/mimir/test/no-useless-predicate/pre320/test.ts.lint
+++ b/baselines/packages/mimir/test/no-useless-predicate/pre320/test.ts.lint
@@ -266,3 +266,44 @@ typeof 1 === TypeOf.String;
 ~~~~~~~~~~~~~~~~~~~~~~~~~~  [error no-useless-predicate: Expression is always falsy.]
 
 typeof true === get<TypeOf>();
+
+declare let arr: Array<true>;
+typeof arr[0] === 'boolean';
+typeof arr[0] === 'undefined';
+typeof arr[0] === 'number';
+~~~~~~~~~~~~~~~~~~~~~~~~~~  [error no-useless-predicate: Expression is always falsy.]
+!arr[0];
+arr[0] === undefined;
+!arr.length;
+!arr['length'];
+!arr[Symbol.iterator];
+ ~~~~~~~~~~~~~~~~~~~~  [error no-useless-predicate: Expression is always truthy.]
+
+declare let tuple: [Date];
+typeof tuple[0] === 'object';
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~  [error no-useless-predicate: Expression is always truthy.]
+typeof tuple[0] === 'undefined';
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  [error no-useless-predicate: Expression is always falsy.]
+typeof tuple[0] === 'number';
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~  [error no-useless-predicate: Expression is always falsy.]
+!tuple[0];
+ ~~~~~~~~  [error no-useless-predicate: Expression is always truthy.]
+tuple[0] === undefined;
+~~~~~~~~~~~~~~~~~~~~~~  [error no-useless-predicate: Expression is always falsy.]
+!tuple.length;
+ ~~~~~~~~~~~~  [error no-useless-predicate: Expression is always truthy.]
+!tuple['length'];
+ ~~~~~~~~~~~~~~~  [error no-useless-predicate: Expression is always truthy.]
+
+declare let indexer: { [s: string]: true; foo: true; bar: true };
+!indexer.foo;
+ ~~~~~~~~~~~  [error no-useless-predicate: Expression is always truthy.]
+!indexer.bar;
+ ~~~~~~~~~~~  [error no-useless-predicate: Expression is always truthy.]
+!indexer.baz;
+!indexer[get<'foo'>()];
+ ~~~~~~~~~~~~~~~~~~~~~  [error no-useless-predicate: Expression is always truthy.]
+!indexer[get<'foo' | 'bar'>()];
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  [error no-useless-predicate: Expression is always truthy.]
+!indexer[get<'foo' | 'baz'>()];
+!indexer[get<string>()];

--- a/packages/mimir/docs/no-useless-predicate.md
+++ b/packages/mimir/docs/no-useless-predicate.md
@@ -16,16 +16,16 @@ This rule consists of 3 distinct checks to detect conditions that are always tru
 
 Types like `{}` or `{toString(): string}` could contain primitive values. Due to a lack of type relationship APIs this rule is currently unable to detect these cases and assumes such types to be always truthy and `typeof` to return `"object"`.
 
-TypeScript doesn't include `undefined` in the type of index signatures. This rule doesn't know whether a certain value came from an index signature. Therefore it reports certain false-positives:
+TypeScript doesn't include `undefined` in the type of index signatures (see [Microsoft/TypeScript#13778](https://github.com/Microsoft/TypeScript/issues/13778)). This rule doesn't know whether a certain value came from an index signature. There's some special handling to treat property access in conditions as potentially `undefined`. Unfortunately there's no reliable way to do the same if the value is assigned to an intermediate variable before using it in a condition:
 
 ```ts
 declare let arr: Array<Date>;
 
-typeof arr[0] === 'object'; // false positive: reported as always truthy
-arr[0] === undefined; // false positive: reported as always falsy
+typeof arr[0] === 'object'; // correctly detected as possibly undefined
+arr[0] === undefined; // correctly detected as possibly undefined
 
-const v1 = arr[1];
-typeof v1 === 'undefined'; // false positive: reported as always falsy
+const v0 = arr[0];
+v0 === undefined; // false positive: the same check as above using a variable doesn't work
 ```
 
 ## Examples

--- a/packages/mimir/src/rules/no-useless-predicate.ts
+++ b/packages/mimir/src/rules/no-useless-predicate.ts
@@ -12,7 +12,10 @@ import {
     isEmptyObjectType,
     isIntersectionType,
     isStrictCompilerOptionEnabled,
+    isPropertyAccessExpression,
+    isElementAccessExpression,
 } from 'tsutils';
+import { lateBoundPropertyNames, getPropertyOfType } from '../utils';
 
 interface TypePredicate {
     nullable: boolean;
@@ -151,7 +154,7 @@ export class Rule extends TypedRule {
                     return;
             }
         }
-        return this.executePredicate(this.checker.getTypeAtLocation(node)!, truthyFalsy);
+        return this.executePredicate(this.getTypeOfExpression(node), truthyFalsy);
     }
 
     private isConstantComparison(left: ts.Expression, right: ts.Expression, operator: ts.EqualityOperator) {
@@ -178,7 +181,7 @@ export class Rule extends TypedRule {
             if (isTextualLiteral(right)) {
                 literal = right.text;
             } else {
-                let type = this.checker.getTypeAtLocation(right)!;
+                let type = this.getTypeOfExpression(right);
                 type = this.checker.getBaseConstraintOfType(type) || type;
                 if ((type.flags & ts.TypeFlags.StringLiteral) === 0)
                     return;
@@ -204,7 +207,7 @@ export class Rule extends TypedRule {
         } else {
             return;
         }
-        return this.nullAwarePredicate(this.checker.getTypeAtLocation(left)!, predicate);
+        return this.nullAwarePredicate(this.getTypeOfExpression(left), predicate);
     }
 
     private nullAwarePredicate(type: ts.Type, predicate: TypePredicate): boolean | undefined {
@@ -266,6 +269,28 @@ export class Rule extends TypedRule {
             }
         }
         return result;
+    }
+
+    private getTypeOfExpression(node: ts.Expression): ts.Type {
+        const type = this.checker.getTypeAtLocation(node);
+        if (!this.strictNullChecks)
+            return type;
+        if (unionTypeParts(type).some((t) => (t.flags & ts.TypeFlags.Undefined) !== 0))
+            return type;
+        if (!isPropertyAccessExpression(node) && !isElementAccessExpression(node))
+            return type;
+        const objectType = this.checker.getApparentType(this.checker.getTypeAtLocation(node.expression));
+        if (objectType.getStringIndexType() === undefined && objectType.getNumberIndexType() === undefined)
+            return type;
+        if (isPropertyAccessExpression(node)) {
+            if (objectType.getProperty(node.name.text) !== undefined)
+                return type;
+        } else {
+            const names = lateBoundPropertyNames(node.argumentExpression, this.checker);
+            if (names.known && names.properties.every(({symbolName}) => getPropertyOfType(objectType, symbolName) !== undefined))
+                return type;
+        }
+        return this.checker.getNullableType(type, ts.TypeFlags.Undefined);
     }
 }
 

--- a/packages/mimir/test/no-useless-predicate/test.ts
+++ b/packages/mimir/test/no-useless-predicate/test.ts
@@ -191,3 +191,31 @@ typeof 1 === TypeOf.Number;
 typeof 1 === TypeOf.String;
 
 typeof true === get<TypeOf>();
+
+declare let arr: Array<true>;
+typeof arr[0] === 'boolean';
+typeof arr[0] === 'undefined';
+typeof arr[0] === 'number';
+!arr[0];
+arr[0] === undefined;
+!arr.length;
+!arr['length'];
+!arr[Symbol.iterator];
+
+declare let tuple: [Date];
+typeof tuple[0] === 'object';
+typeof tuple[0] === 'undefined';
+typeof tuple[0] === 'number';
+!tuple[0];
+tuple[0] === undefined;
+!tuple.length;
+!tuple['length'];
+
+declare let indexer: { [s: string]: true; foo: true; bar: true };
+!indexer.foo;
+!indexer.bar;
+!indexer.baz;
+!indexer[get<'foo'>()];
+!indexer[get<'foo' | 'bar'>()];
+!indexer[get<'foo' | 'baz'>()];
+!indexer[get<string>()];

--- a/packages/mimir/test/no-useless-predicate/tsconfig.json
+++ b/packages/mimir/test/no-useless-predicate/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
-    "strict": true
+    "strict": true,
+    "target": "esnext"
   }
 }


### PR DESCRIPTION
#### Checklist

- [x] Fixes: #522
- [x] Added or updated tests / baselines
- [x] Documentation update

#### Overview of change 
If a property access or element access matches an index signature, treat the resulting type as optional (i.e. include `undefined`).
If there are known properties in addition to the index signature, the type is not optional if every accessed property has a corresponding known property.

This will not work for intermediate variables assigned from a property of an indexer.

/cc @CSchulz