### PR TITLE
no-useless-predicate: everything can be falsy without strictNullChecks

### DIFF
--- a/baselines/packages/mimir/test/no-useless-predicate/loose/test.ts.lint
+++ b/baselines/packages/mimir/test/no-useless-predicate/loose/test.ts.lint
@@ -10,9 +10,7 @@ if (get<unknown>()) {}
 if (get<never>()) {}
 if ((typeof 1 === 'number')) {}
 if ((get<Record<string, Function>>().foo)) {}
-     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~      [error no-useless-predicate: Expression is always truthy.]
 if (!(get<Record<string, Function>>().foo)) {}
-     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~     [error no-useless-predicate: Expression is always truthy.]
 while (typeof get<any>() === 'symbol') {}
 while (typeof get<unknown>() === 'symbol') {}
 while (typeof get<never>() === 'symbol') {}
@@ -36,7 +34,6 @@ while ('foo' !== undefined && 'bar' == null) {}
 while (get<number>() + get<number>());
 
 true ? 'foo' : 'bar';
-~~~~                  [error no-useless-predicate: Expression is always truthy.]
 1 === undefined ? 'bar' : 'foo';
 
 +0;
@@ -69,24 +66,18 @@ undefined == get<null>();
 get<undefined>() == null;
 
 !get<1>();
- ~~~~~~~~  [error no-useless-predicate: Expression is always truthy.]
 !get<0>();
  ~~~~~~~~  [error no-useless-predicate: Expression is always falsy.]
 !get<number>();
 !!get<boolean>();
 !get<string>();
 !!get<'foo'>();
- ~~~~~~~~~~~~~  [error no-useless-predicate: Expression is always falsy.]
-  ~~~~~~~~~~~~  [error no-useless-predicate: Expression is always truthy.]
 !!get<true>();
- ~~~~~~~~~~~~  [error no-useless-predicate: Expression is always falsy.]
-  ~~~~~~~~~~~  [error no-useless-predicate: Expression is always truthy.]
 !get<{}>();
 !!get<false>()
  ~~~~~~~~~~~~~ [error no-useless-predicate: Expression is always truthy.]
   ~~~~~~~~~~~~ [error no-useless-predicate: Expression is always falsy.]
 !get<{foo: 'bar'}>();
- ~~~~~~~~~~~~~~~~~~~  [error no-useless-predicate: Expression is always truthy.]
 
 for (;;) break;
 while (true) break;
@@ -197,27 +188,20 @@ const enum E2 {
 !E.Foo;
  ~~~~~  [error no-useless-predicate: Expression is always falsy.]
 !E.Bar;
- ~~~~~  [error no-useless-predicate: Expression is always truthy.]
 !E.Baz;
- ~~~~~  [error no-useless-predicate: Expression is always truthy.]
 !CE.Foo;
  ~~~~~~  [error no-useless-predicate: Expression is always falsy.]
 !CE.Bar;
- ~~~~~~  [error no-useless-predicate: Expression is always truthy.]
 !CE.Baz;
- ~~~~~~  [error no-useless-predicate: Expression is always truthy.]
 !CSE.Foo;
  ~~~~~~~  [error no-useless-predicate: Expression is always falsy.]
 !CSE.Bar;
- ~~~~~~~  [error no-useless-predicate: Expression is always truthy.]
 
 !get<E.Foo | CE.Foo | CSE.Foo>();
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  [error no-useless-predicate: Expression is always falsy.]
 !get<E.Foo | CE.Foo | CSE.Bar>();
 !get<E.Bar | CE.Bar | CSE.Bar>();
- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  [error no-useless-predicate: Expression is always truthy.]
 !get<E2>();
- ~~~~~~~~~  [error no-useless-predicate: Expression is always truthy.]
 
 const TypeOfString = 'string';
 
@@ -241,12 +225,10 @@ typeof arr[0] === 'undefined';
 typeof arr[0] === 'number';
 ~~~~~~~~~~~~~~~~~~~~~~~~~~  [error no-useless-predicate: Expression is always falsy.]
 !arr[0];
- ~~~~~~  [error no-useless-predicate: Expression is always truthy.]
 arr[0] === undefined;
 !arr.length;
 !arr['length'];
 !arr[Symbol.iterator];
- ~~~~~~~~~~~~~~~~~~~~  [error no-useless-predicate: Expression is always truthy.]
 
 declare let tuple: [Date];
 typeof tuple[0] === 'object';
@@ -254,25 +236,15 @@ typeof tuple[0] === 'undefined';
 typeof tuple[0] === 'number';
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~  [error no-useless-predicate: Expression is always falsy.]
 !tuple[0];
- ~~~~~~~~  [error no-useless-predicate: Expression is always truthy.]
 tuple[0] === undefined;
 !tuple.length;
- ~~~~~~~~~~~~  [error no-useless-predicate: Expression is always truthy.]
 !tuple['length'];
- ~~~~~~~~~~~~~~~  [error no-useless-predicate: Expression is always truthy.]
 
 declare let indexer: { [s: string]: true; foo: true; bar: true };
 !indexer.foo;
- ~~~~~~~~~~~  [error no-useless-predicate: Expression is always truthy.]
 !indexer.bar;
- ~~~~~~~~~~~  [error no-useless-predicate: Expression is always truthy.]
 !indexer.baz;
- ~~~~~~~~~~~  [error no-useless-predicate: Expression is always truthy.]
 !indexer[get<'foo'>()];
- ~~~~~~~~~~~~~~~~~~~~~  [error no-useless-predicate: Expression is always truthy.]
 !indexer[get<'foo' | 'bar'>()];
- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  [error no-useless-predicate: Expression is always truthy.]
 !indexer[get<'foo' | 'baz'>()];
- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  [error no-useless-predicate: Expression is always truthy.]
 !indexer[get<string>()];
- ~~~~~~~~~~~~~~~~~~~~~~  [error no-useless-predicate: Expression is always truthy.]

--- a/packages/mimir/src/rules/no-useless-predicate.ts
+++ b/packages/mimir/src/rules/no-useless-predicate.ts
@@ -157,7 +157,8 @@ export class Rule extends TypedRule {
         } else if (isParenthesizedExpression(node)) {
             return this.isTruthyFalsy(node.expression);
         }
-        return this.executePredicate(this.getTypeOfExpression(node), truthyFalsy);
+        // in non-strictNullChecks mode we can only detect if a type is definitely falsy
+        return this.executePredicate(this.getTypeOfExpression(node), this.strictNullChecks ? truthyFalsy : falsy);
     }
 
     private isConstantComparison(left: ts.Expression, right: ts.Expression, operator: ts.EqualityOperator) {
@@ -298,6 +299,10 @@ export class Rule extends TypedRule {
 
 function isUndefined(node: ts.Expression): node is ts.Identifier {
     return isIdentifier(node) && node.originalKeywordKind === ts.SyntaxKind.UndefinedKeyword;
+}
+
+function falsy(type: ts.Type): false | undefined {
+    return isFalsyType(type) ? false : undefined;
 }
 
 function truthyFalsy(type: ts.Type) {


### PR DESCRIPTION
Without `strictNullChecks` everything can be falsy. Therefore we can only detect definitely falsy expressions.
