### PR TITLE
 no-useless-predicate: fix 'typeof {} === "object"'

### DIFF
--- a/baselines/packages/mimir/test/no-useless-predicate/default/test.ts.lint
+++ b/baselines/packages/mimir/test/no-useless-predicate/default/test.ts.lint
@@ -20,7 +20,6 @@ while (typeof get<unknown>() === 'symbol') {}
 while (typeof get<never>() === 'symbol') {}
 while (typeof get<{}>() === 'number') ;
 while (typeof get<{}>() == 'object') ;
-       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~    [error no-useless-predicate: Expression is always truthy.]
 while (typeof get<{}>() == 'undefined') ;
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~    [error no-useless-predicate: Expression is always falsy.]
 while (typeof get<{a: number} & {b: string}>() === 'object') ;

--- a/baselines/packages/mimir/test/no-useless-predicate/pre320/test.ts.lint
+++ b/baselines/packages/mimir/test/no-useless-predicate/pre320/test.ts.lint
@@ -20,7 +20,6 @@ while (typeof get<unknown>() === 'symbol') {}
 while (typeof get<never>() === 'symbol') {}
 while (typeof get<{}>() === 'number') ;
 while (typeof get<{}>() == 'object') ;
-       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~    [error no-useless-predicate: Expression is always truthy.]
 while (typeof get<{}>() == 'undefined') ;
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~    [error no-useless-predicate: Expression is always falsy.]
 while (typeof get<{a: number} & {b: string}>() === 'object') ;

--- a/packages/mimir/src/rules/no-useless-predicate.ts
+++ b/packages/mimir/src/rules/no-useless-predicate.ts
@@ -20,7 +20,7 @@ import { lateBoundPropertyNames, getPropertyOfType, unwrapParens, formatPseudoBi
 
 interface TypePredicate {
     nullable: boolean;
-    check(type: ts.Type): boolean;
+    check(type: ts.Type): boolean | undefined;
 }
 
 interface Equals {
@@ -35,7 +35,7 @@ const predicates: Record<string, TypePredicate> = {
     object: {
         nullable: true,
         check(type) {
-            return (type.flags & primitiveFlags) === 0 && !isTypeofFunction(type);
+            return isEmptyObjectType(type) ? undefined : (type.flags & primitiveFlags) === 0 && !isTypeofFunction(type);
         },
     },
     number: {


### PR DESCRIPTION
#### Checklist

- [x] Fixes: #535 
- [x] Added or updated tests / baselines
