### PR TITLE
no-inferred-empty-object: handle higher order function type inference

### DIFF
--- a/baselines/packages/mimir/test/no-inferred-empty-object/330/js.js.lint
+++ b/baselines/packages/mimir/test/no-inferred-empty-object/330/js.js.lint
@@ -1,0 +1,83 @@
+/** Some comment */
+export function nonGenericJs() {}
+
+/**
+ * @template T lorem ipsum
+ * @param {T} [p1]
+ * @return {T}
+ */
+export function fn(p1){
+    return p1;
+}
+
+/**
+ * @template T
+ * @param {Array<T>} [p1]
+ * @return {T}
+ */
+export function arrayFn(p1){
+    return p1[0];
+}
+
+/** @function */
+/**
+ * @template T, U, V
+ *
+ * @param {T} [a]
+ * @param {U} [b]
+ * @param {V} [c]
+ */
+export function multiParam(a, b, c) {}
+
+/** @template T */
+/**
+ * @template U, V
+ *
+ * @param {T} [a]
+ * @param {U} [b]
+ * @param {V} [c]
+ */
+export function weirdMultiParam(a, b, c) {}
+
+fn();
+fn(1);
+fn({});
+arrayFn();
+arrayFn([]);
+arrayFn([1]);
+arrayFn([{}]);
+multiParam();
+
+/**
+ * @template T
+ * @param {T} [param]
+ * @class
+ */
+export function JsClass(param) {
+    this.value = param;
+}
+JsClass.prototype.doStuff = function() {
+    return this.value;
+}
+
+/**
+ * @template T
+ */
+export class RealJsClass {
+    /**
+     * @param {T} [value]
+     */
+    constructor(value) {
+        this.value = value;
+    }
+}
+
+/** @type {<T>(param?: T) => T} */
+export var functionTyped;
+
+/**
+ * @template T
+ * @callback Cb
+ * @param {T} [a]
+ */
+export function notGeneric(a) {}

--- a/baselines/packages/mimir/test/no-inferred-empty-object/330/jsx.tsx.lint
+++ b/baselines/packages/mimir/test/no-inferred-empty-object/330/jsx.tsx.lint
@@ -1,0 +1,62 @@
+declare namespace JSX {
+    interface IntrinsicElements {
+        [elemName: string]: any;
+    }
+
+    interface Element {
+        render(): Element;
+        props: any;
+    }
+
+    interface ElementAttributesProperty {
+        props: any;
+    }
+}
+
+function SFC<T>(props: Record<string, T>) {
+    return {
+        props: props,
+    };
+}
+
+let foo = <SFC></SFC>;
+          ~~~~~        [error no-inferred-empty-object: TypeParameter 'T' is inferred as '{}'. Consider adding type arguments to the call.]
+foo = <SFC/>;
+      ~~~~~~  [error no-inferred-empty-object: TypeParameter 'T' is inferred as '{}'. Consider adding type arguments to the call.]
+foo = <SFC<string>/>;
+foo = <SFC<string>></SFC>;
+foo = <SFC<string> prop="1"></SFC>;
+foo = <SFC prop="foo"/>;
+foo = <SFC prop="foo" other={1}></SFC>;
+
+interface MyComponentConstructor {
+    new<T>(props: Record<string, T>): MyComponent<T>;
+}
+
+declare const MyComponentConstructor: MyComponentConstructor;
+
+class MyComponent<T> {
+    constructor(private props: Record<string, T>) {}
+
+    render() { return this; }
+}
+
+foo = <MyComponentConstructor></MyComponentConstructor>;
+      ~~~~~~~~~~~~~~~~~~~~~~~~                           [error no-inferred-empty-object: TypeParameter 'T' is inferred as '{}'. Consider adding type arguments to the call.]
+foo = <MyComponentConstructor<string>></MyComponentConstructor>;
+foo = <MyComponentConstructor prop="1"></MyComponentConstructor>;
+foo = <MyComponent></MyComponent>;
+foo = <MyComponent<string>></MyComponent>;
+foo = <MyComponent prop="1"></MyComponent>;
+
+function MyFactoryComponent<T>(props: Record<string, T>) {
+    return {
+        render() { return this; },
+        props,
+    };
+}
+
+foo = <MyFactoryComponent></MyFactoryComponent>;
+      ~~~~~~~~~~~~~~~~~~~~                       [error no-inferred-empty-object: TypeParameter 'T' is inferred as '{}'. Consider adding type arguments to the call.]
+foo = <MyFactoryComponent prop="1"></MyFactoryComponent>;
+foo = <MyFactoryComponent<string>></MyFactoryComponent>;

--- a/baselines/packages/mimir/test/no-inferred-empty-object/330/test.ts.lint
+++ b/baselines/packages/mimir/test/no-inferred-empty-object/330/test.ts.lint
@@ -354,3 +354,31 @@ unified2();
 const unified3 = Boolean() ? (a?: string) => undefined : <T = string>(param?: T) => param;
 unified3('2');
 unified3();
+
+declare const unified4: {(): void; (param?: string): string} | (<T>(param?: T) => T);
+unified4('1');
+unified4();
+~~~~~~~~~~  [error no-inferred-empty-object: TypeParameter 'T' is inferred as '{}'. Consider adding type arguments to the call.]
+
+declare const unified5: (<T>(a?: T) => T) | {(): void; (param?: string): string};
+unified5('1');
+unified5();
+~~~~~~~~~~  [error no-inferred-empty-object: TypeParameter 'T' is inferred as '{}'. Consider adding type arguments to the call.]
+
+declare const unified6: (<T = string>(a?: T) => T) | {(): void; (param?: string): string};
+unified6('1');
+unified6();
+
+declare function overloaded<T>(): void;
+declare function overloaded<T, U>(param: T): void;
+declare function overloaded<T, U, V, W = string>(a: T, b: T): void;
+declare function overloaded(a: string, b: string, c: string): void;
+
+overloaded();
+~~~~~~~~~~~~  [error no-inferred-empty-object: TypeParameter 'T' is inferred as '{}'. Consider adding type arguments to the call.]
+overloaded(1);
+~~~~~~~~~~~~~  [error no-inferred-empty-object: TypeParameter 'U' is inferred as '{}'. Consider adding type arguments to the call.]
+overloaded(1, 2);
+~~~~~~~~~~~~~~~~  [error no-inferred-empty-object: TypeParameter 'U' is inferred as '{}'. Consider adding type arguments to the call.]
+~~~~~~~~~~~~~~~~  [error no-inferred-empty-object: TypeParameter 'V' is inferred as '{}'. Consider adding type arguments to the call.]
+overloaded('', '', '');

--- a/baselines/packages/mimir/test/no-inferred-empty-object/330/test.ts.lint
+++ b/baselines/packages/mimir/test/no-inferred-empty-object/330/test.ts.lint
@@ -271,6 +271,9 @@ new Promise<object>((resolve, reject) => {
 
 declare function myTagFn<T>(parts: TemplateStringsArray, ...values: T[]): string;
 declare function myOtherTag<T>(parts: TemplateStringsArray): T;
+declare function tag(parts: TemplateStringsArray): string;
+
+tag``;
 
 myTagFn``;
 ~~~~~~~~~  [error no-inferred-empty-object: TypeParameter 'T' is inferred as '{}'. Consider adding type arguments to the call.]
@@ -382,3 +385,6 @@ overloaded(1, 2);
 ~~~~~~~~~~~~~~~~  [error no-inferred-empty-object: TypeParameter 'U' is inferred as '{}'. Consider adding type arguments to the call.]
 ~~~~~~~~~~~~~~~~  [error no-inferred-empty-object: TypeParameter 'V' is inferred as '{}'. Consider adding type arguments to the call.]
 overloaded('', '', '');
+
+declare let untyped: Function;
+untyped();

--- a/baselines/packages/mimir/test/no-inferred-empty-object/330/test.ts.lint
+++ b/baselines/packages/mimir/test/no-inferred-empty-object/330/test.ts.lint
@@ -243,15 +243,12 @@ new C2<string>();
 
 // avoid false positives while parsing type arguments
 withOneDefault(<T>(param: T) => param);
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  [error no-inferred-empty-object: TypeParameter 'T' is inferred as '{}'. Consider adding type arguments to the call.]
 withOneDefault({key: {}, anotherKey: {nested: {}}});
 withOneDefault(fn);
-~~~~~~~~~~~~~~~~~~  [error no-inferred-empty-object: TypeParameter 'T' is inferred as '{}'. Consider adding type arguments to the call.]
 withOneDefault(new Wrapper<{}>());
 withOneDefault({key: new Wrapper<{}>()});
 withOneDefault({'{}, {}': [{}]});
 withOneDefault((() => 1) as {<T>(param: T): T});
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  [error no-inferred-empty-object: TypeParameter 'T' is inferred as '{}'. Consider adding type arguments to the call.]
 
 /**
  * @template T
@@ -306,7 +303,6 @@ list();
 const listBox = pipe(list, box);
 listBox(1);
 listBox();
-~~~~~~~~~  [error no-inferred-empty-object: TypeParameter 'T' is inferred as '{}'. Consider adding type arguments to the call.]
 
 const list2Box = pipe(list2, box);
 list2Box(1);
@@ -315,34 +311,34 @@ list2Box();
 declare function pipe2<A, B, C, D>(ab: (a: A) => B, cd: (c: C) => D): (a?: [A, C] | [A]) => [B, D];
 
 const listList = pipe2(list, list);
+                 ~~~~~~~~~~~~~~~~~  [error no-inferred-empty-object: TypeParameter 'A' is inferred as '{}'. Consider adding type arguments to the call.]
+                 ~~~~~~~~~~~~~~~~~  [error no-inferred-empty-object: TypeParameter 'C' is inferred as '{}'. Consider adding type arguments to the call.]
 listList([1, '2']);
 listList([1]);
-~~~~~~~~~~~~~  [error no-inferred-empty-object: TypeParameter 'T1' is inferred as '{}'. Consider adding type arguments to the call.]
 listList();
-~~~~~~~~~~  [error no-inferred-empty-object: TypeParameter 'T' is inferred as '{}'. Consider adding type arguments to the call.]
-~~~~~~~~~~  [error no-inferred-empty-object: TypeParameter 'T1' is inferred as '{}'. Consider adding type arguments to the call.]
 
 const list2List = pipe2(list, list2);
+                  ~~~~~~~~~~~~~~~~~~  [error no-inferred-empty-object: TypeParameter 'A' is inferred as '{}'. Consider adding type arguments to the call.]
+                  ~~~~~~~~~~~~~~~~~~  [error no-inferred-empty-object: TypeParameter 'C' is inferred as '{}'. Consider adding type arguments to the call.]
 list2List([1, '2']);
 list2List([1]);
 list2List();
-~~~~~~~~~~~  [error no-inferred-empty-object: TypeParameter 'T' is inferred as '{}'. Consider adding type arguments to the call.]
 
 function pipe3<A, B, C, D>(ab: (a?: A) => B, cd: (c?: C) => D) {
     return (a?: A, c?: C) => [ab(a), cd(c)] as const;
 }
 
 const listList2 = pipe3(list, list);
+                  ~~~~~~~~~~~~~~~~~  [error no-inferred-empty-object: TypeParameter 'A' is inferred as '{}'. Consider adding type arguments to the call.]
+                  ~~~~~~~~~~~~~~~~~  [error no-inferred-empty-object: TypeParameter 'C' is inferred as '{}'. Consider adding type arguments to the call.]
 listList2(1, '2');
 listList2(1);
-~~~~~~~~~~~~  [error no-inferred-empty-object: TypeParameter 'T1' is inferred as '{}'. Consider adding type arguments to the call.]
 listList2();
-~~~~~~~~~~~  [error no-inferred-empty-object: TypeParameter 'T' is inferred as '{}'. Consider adding type arguments to the call.]
-~~~~~~~~~~~  [error no-inferred-empty-object: TypeParameter 'T1' is inferred as '{}'. Consider adding type arguments to the call.]
 
 declare function pipe4<A extends any[], B, C>(ab: (...args: A) => B, bc?: (b: B) => C): (...args: A) => C;
 
 const listNone = pipe4(list);
+                 ~~~~~~~~~~~  [error no-inferred-empty-object: TypeParameter 'C' is inferred as '{}'. Consider adding type arguments to the call.]
 listNone(1);
 
 const unified = Boolean() ? <T>(param?: T) => param : () => undefined;

--- a/baselines/packages/mimir/test/no-inferred-empty-object/default/test.ts.lint
+++ b/baselines/packages/mimir/test/no-inferred-empty-object/default/test.ts.lint
@@ -358,3 +358,31 @@ unified2();
 const unified3 = Boolean() ? (a?: string) => undefined : <T = string>(param?: T) => param;
 unified3('2');
 unified3();
+
+declare const unified4: {(): void; (param?: string): string} | (<T>(param?: T) => T);
+unified4('1');
+unified4();
+~~~~~~~~~~  [error no-inferred-empty-object: TypeParameter 'T' is inferred as '{}'. Consider adding type arguments to the call.]
+
+declare const unified5: (<T>(a?: T) => T) | {(): void; (param?: string): string};
+unified5('1');
+unified5();
+~~~~~~~~~~  [error no-inferred-empty-object: TypeParameter 'T' is inferred as '{}'. Consider adding type arguments to the call.]
+
+declare const unified6: (<T = string>(a?: T) => T) | {(): void; (param?: string): string};
+unified6('1');
+unified6();
+
+declare function overloaded<T>(): void;
+declare function overloaded<T, U>(param: T): void;
+declare function overloaded<T, U, V, W = string>(a: T, b: T): void;
+declare function overloaded(a: string, b: string, c: string): void;
+
+overloaded();
+~~~~~~~~~~~~  [error no-inferred-empty-object: TypeParameter 'T' is inferred as '{}'. Consider adding type arguments to the call.]
+overloaded(1);
+~~~~~~~~~~~~~  [error no-inferred-empty-object: TypeParameter 'U' is inferred as '{}'. Consider adding type arguments to the call.]
+overloaded(1, 2);
+~~~~~~~~~~~~~~~~  [error no-inferred-empty-object: TypeParameter 'U' is inferred as '{}'. Consider adding type arguments to the call.]
+~~~~~~~~~~~~~~~~  [error no-inferred-empty-object: TypeParameter 'V' is inferred as '{}'. Consider adding type arguments to the call.]
+overloaded('', '', '');

--- a/baselines/packages/mimir/test/no-inferred-empty-object/default/test.ts.lint
+++ b/baselines/packages/mimir/test/no-inferred-empty-object/default/test.ts.lint
@@ -274,6 +274,9 @@ new Promise<object>((resolve, reject) => {
 
 declare function myTagFn<T>(parts: TemplateStringsArray, ...values: T[]): string;
 declare function myOtherTag<T>(parts: TemplateStringsArray): T;
+declare function tag(parts: TemplateStringsArray): string;
+
+tag``;
 
 myTagFn``;
 ~~~~~~~~~  [error no-inferred-empty-object: TypeParameter 'T' is inferred as '{}'. Consider adding type arguments to the call.]
@@ -386,3 +389,6 @@ overloaded(1, 2);
 ~~~~~~~~~~~~~~~~  [error no-inferred-empty-object: TypeParameter 'U' is inferred as '{}'. Consider adding type arguments to the call.]
 ~~~~~~~~~~~~~~~~  [error no-inferred-empty-object: TypeParameter 'V' is inferred as '{}'. Consider adding type arguments to the call.]
 overloaded('', '', '');
+
+declare let untyped: Function;
+untyped();

--- a/baselines/packages/mimir/test/no-inferred-empty-object/pre330/js.js.lint
+++ b/baselines/packages/mimir/test/no-inferred-empty-object/pre330/js.js.lint
@@ -1,0 +1,83 @@
+/** Some comment */
+export function nonGenericJs() {}
+
+/**
+ * @template T lorem ipsum
+ * @param {T} [p1]
+ * @return {T}
+ */
+export function fn(p1){
+    return p1;
+}
+
+/**
+ * @template T
+ * @param {Array<T>} [p1]
+ * @return {T}
+ */
+export function arrayFn(p1){
+    return p1[0];
+}
+
+/** @function */
+/**
+ * @template T, U, V
+ *
+ * @param {T} [a]
+ * @param {U} [b]
+ * @param {V} [c]
+ */
+export function multiParam(a, b, c) {}
+
+/** @template T */
+/**
+ * @template U, V
+ *
+ * @param {T} [a]
+ * @param {U} [b]
+ * @param {V} [c]
+ */
+export function weirdMultiParam(a, b, c) {}
+
+fn();
+fn(1);
+fn({});
+arrayFn();
+arrayFn([]);
+arrayFn([1]);
+arrayFn([{}]);
+multiParam();
+
+/**
+ * @template T
+ * @param {T} [param]
+ * @class
+ */
+export function JsClass(param) {
+    this.value = param;
+}
+JsClass.prototype.doStuff = function() {
+    return this.value;
+}
+
+/**
+ * @template T
+ */
+export class RealJsClass {
+    /**
+     * @param {T} [value]
+     */
+    constructor(value) {
+        this.value = value;
+    }
+}
+
+/** @type {<T>(param?: T) => T} */
+export var functionTyped;
+
+/**
+ * @template T
+ * @callback Cb
+ * @param {T} [a]
+ */
+export function notGeneric(a) {}

--- a/baselines/packages/mimir/test/no-inferred-empty-object/pre330/jsx.tsx.lint
+++ b/baselines/packages/mimir/test/no-inferred-empty-object/pre330/jsx.tsx.lint
@@ -1,0 +1,62 @@
+declare namespace JSX {
+    interface IntrinsicElements {
+        [elemName: string]: any;
+    }
+
+    interface Element {
+        render(): Element;
+        props: any;
+    }
+
+    interface ElementAttributesProperty {
+        props: any;
+    }
+}
+
+function SFC<T>(props: Record<string, T>) {
+    return {
+        props: props,
+    };
+}
+
+let foo = <SFC></SFC>;
+          ~~~~~        [error no-inferred-empty-object: TypeParameter 'T' is inferred as '{}'. Consider adding type arguments to the call.]
+foo = <SFC/>;
+      ~~~~~~  [error no-inferred-empty-object: TypeParameter 'T' is inferred as '{}'. Consider adding type arguments to the call.]
+foo = <SFC<string>/>;
+foo = <SFC<string>></SFC>;
+foo = <SFC<string> prop="1"></SFC>;
+foo = <SFC prop="foo"/>;
+foo = <SFC prop="foo" other={1}></SFC>;
+
+interface MyComponentConstructor {
+    new<T>(props: Record<string, T>): MyComponent<T>;
+}
+
+declare const MyComponentConstructor: MyComponentConstructor;
+
+class MyComponent<T> {
+    constructor(private props: Record<string, T>) {}
+
+    render() { return this; }
+}
+
+foo = <MyComponentConstructor></MyComponentConstructor>;
+      ~~~~~~~~~~~~~~~~~~~~~~~~                           [error no-inferred-empty-object: TypeParameter 'T' is inferred as '{}'. Consider adding type arguments to the call.]
+foo = <MyComponentConstructor<string>></MyComponentConstructor>;
+foo = <MyComponentConstructor prop="1"></MyComponentConstructor>;
+foo = <MyComponent></MyComponent>;
+foo = <MyComponent<string>></MyComponent>;
+foo = <MyComponent prop="1"></MyComponent>;
+
+function MyFactoryComponent<T>(props: Record<string, T>) {
+    return {
+        render() { return this; },
+        props,
+    };
+}
+
+foo = <MyFactoryComponent></MyFactoryComponent>;
+      ~~~~~~~~~~~~~~~~~~~~                       [error no-inferred-empty-object: TypeParameter 'T' is inferred as '{}'. Consider adding type arguments to the call.]
+foo = <MyFactoryComponent prop="1"></MyFactoryComponent>;
+foo = <MyFactoryComponent<string>></MyFactoryComponent>;

--- a/baselines/packages/mimir/test/no-inferred-empty-object/pre330/test.ts.lint
+++ b/baselines/packages/mimir/test/no-inferred-empty-object/pre330/test.ts.lint
@@ -353,3 +353,29 @@ unified2();
 const unified3 = Boolean() ? (a?: string) => undefined : <T = string>(param?: T) => param;
 unified3('2');
 unified3();
+
+declare const unified4: {(): void; (param?: string): string} | (<T>(param?: T) => T);
+unified4('1');
+unified4();
+
+declare const unified5: (<T>(a?: T) => T) | {(): void; (param?: string): string};
+unified5('1');
+unified5();
+
+declare const unified6: (<T = string>(a?: T) => T) | {(): void; (param?: string): string};
+unified6('1');
+unified6();
+
+declare function overloaded<T>(): void;
+declare function overloaded<T, U>(param: T): void;
+declare function overloaded<T, U, V, W = string>(a: T, b: T): void;
+declare function overloaded(a: string, b: string, c: string): void;
+
+overloaded();
+~~~~~~~~~~~~  [error no-inferred-empty-object: TypeParameter 'T' is inferred as '{}'. Consider adding type arguments to the call.]
+overloaded(1);
+~~~~~~~~~~~~~  [error no-inferred-empty-object: TypeParameter 'U' is inferred as '{}'. Consider adding type arguments to the call.]
+overloaded(1, 2);
+~~~~~~~~~~~~~~~~  [error no-inferred-empty-object: TypeParameter 'U' is inferred as '{}'. Consider adding type arguments to the call.]
+~~~~~~~~~~~~~~~~  [error no-inferred-empty-object: TypeParameter 'V' is inferred as '{}'. Consider adding type arguments to the call.]
+overloaded('', '', '');

--- a/baselines/packages/mimir/test/no-inferred-empty-object/pre330/test.ts.lint
+++ b/baselines/packages/mimir/test/no-inferred-empty-object/pre330/test.ts.lint
@@ -243,15 +243,12 @@ new C2<string>();
 
 // avoid false positives while parsing type arguments
 withOneDefault(<T>(param: T) => param);
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  [error no-inferred-empty-object: TypeParameter 'T' is inferred as '{}'. Consider adding type arguments to the call.]
 withOneDefault({key: {}, anotherKey: {nested: {}}});
 withOneDefault(fn);
-~~~~~~~~~~~~~~~~~~  [error no-inferred-empty-object: TypeParameter 'T' is inferred as '{}'. Consider adding type arguments to the call.]
 withOneDefault(new Wrapper<{}>());
 withOneDefault({key: new Wrapper<{}>()});
 withOneDefault({'{}, {}': [{}]});
 withOneDefault((() => 1) as {<T>(param: T): T});
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  [error no-inferred-empty-object: TypeParameter 'T' is inferred as '{}'. Consider adding type arguments to the call.]
 
 /**
  * @template T
@@ -306,7 +303,6 @@ list();
 const listBox = pipe(list, box);
 listBox(1);
 listBox();
-~~~~~~~~~  [error no-inferred-empty-object: TypeParameter 'T' is inferred as '{}'. Consider adding type arguments to the call.]
 
 const list2Box = pipe(list2, box);
 list2Box(1);
@@ -315,34 +311,34 @@ list2Box();
 declare function pipe2<A, B, C, D>(ab: (a: A) => B, cd: (c: C) => D): (a?: [A, C] | [A]) => [B, D];
 
 const listList = pipe2(list, list);
+                 ~~~~~~~~~~~~~~~~~  [error no-inferred-empty-object: TypeParameter 'A' is inferred as '{}'. Consider adding type arguments to the call.]
+                 ~~~~~~~~~~~~~~~~~  [error no-inferred-empty-object: TypeParameter 'C' is inferred as '{}'. Consider adding type arguments to the call.]
 listList([1, '2']);
 listList([1]);
-~~~~~~~~~~~~~  [error no-inferred-empty-object: TypeParameter 'T1' is inferred as '{}'. Consider adding type arguments to the call.]
 listList();
-~~~~~~~~~~  [error no-inferred-empty-object: TypeParameter 'T' is inferred as '{}'. Consider adding type arguments to the call.]
-~~~~~~~~~~  [error no-inferred-empty-object: TypeParameter 'T1' is inferred as '{}'. Consider adding type arguments to the call.]
 
 const list2List = pipe2(list, list2);
+                  ~~~~~~~~~~~~~~~~~~  [error no-inferred-empty-object: TypeParameter 'A' is inferred as '{}'. Consider adding type arguments to the call.]
+                  ~~~~~~~~~~~~~~~~~~  [error no-inferred-empty-object: TypeParameter 'C' is inferred as '{}'. Consider adding type arguments to the call.]
 list2List([1, '2']);
 list2List([1]);
 list2List();
-~~~~~~~~~~~  [error no-inferred-empty-object: TypeParameter 'T' is inferred as '{}'. Consider adding type arguments to the call.]
 
 function pipe3<A, B, C, D>(ab: (a?: A) => B, cd: (c?: C) => D) {
     return (a?: A, c?: C) => [ab(a), cd(c)] as const;
 }
 
 const listList2 = pipe3(list, list);
+                  ~~~~~~~~~~~~~~~~~  [error no-inferred-empty-object: TypeParameter 'A' is inferred as '{}'. Consider adding type arguments to the call.]
+                  ~~~~~~~~~~~~~~~~~  [error no-inferred-empty-object: TypeParameter 'C' is inferred as '{}'. Consider adding type arguments to the call.]
 listList2(1, '2');
 listList2(1);
-~~~~~~~~~~~~  [error no-inferred-empty-object: TypeParameter 'T1' is inferred as '{}'. Consider adding type arguments to the call.]
 listList2();
-~~~~~~~~~~~  [error no-inferred-empty-object: TypeParameter 'T' is inferred as '{}'. Consider adding type arguments to the call.]
-~~~~~~~~~~~  [error no-inferred-empty-object: TypeParameter 'T1' is inferred as '{}'. Consider adding type arguments to the call.]
 
 declare function pipe4<A extends any[], B, C>(ab: (...args: A) => B, bc?: (b: B) => C): (...args: A) => C;
 
 const listNone = pipe4(list);
+                 ~~~~~~~~~~~  [error no-inferred-empty-object: TypeParameter 'C' is inferred as '{}'. Consider adding type arguments to the call.]
 listNone(1);
 
 const unified = Boolean() ? <T>(param?: T) => param : () => undefined;
@@ -353,7 +349,6 @@ unified();
 const unified2 = Boolean() ? (a?: string) => undefined : <T>(param?: T) => param;
 unified2('2');
 unified2();
-~~~~~~~~~~  [error no-inferred-empty-object: TypeParameter 'T' is inferred as '{}'. Consider adding type arguments to the call.]
 
 const unified3 = Boolean() ? (a?: string) => undefined : <T = string>(param?: T) => param;
 unified3('2');

--- a/baselines/packages/mimir/test/no-inferred-empty-object/pre330/test.ts.lint
+++ b/baselines/packages/mimir/test/no-inferred-empty-object/pre330/test.ts.lint
@@ -271,6 +271,9 @@ new Promise<object>((resolve, reject) => {
 
 declare function myTagFn<T>(parts: TemplateStringsArray, ...values: T[]): string;
 declare function myOtherTag<T>(parts: TemplateStringsArray): T;
+declare function tag(parts: TemplateStringsArray): string;
+
+tag``;
 
 myTagFn``;
 ~~~~~~~~~  [error no-inferred-empty-object: TypeParameter 'T' is inferred as '{}'. Consider adding type arguments to the call.]
@@ -379,3 +382,6 @@ overloaded(1, 2);
 ~~~~~~~~~~~~~~~~  [error no-inferred-empty-object: TypeParameter 'U' is inferred as '{}'. Consider adding type arguments to the call.]
 ~~~~~~~~~~~~~~~~  [error no-inferred-empty-object: TypeParameter 'V' is inferred as '{}'. Consider adding type arguments to the call.]
 overloaded('', '', '');
+
+declare let untyped: Function;
+untyped();

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "ttypescript": "^1.5.5"
   },
   "devDependencies": {
-    "typescript": "^3.4.0-dev.20190309"
+    "typescript": "3.4.0-dev.20190310"
   },
   "peerDependencies": {
     "typescript": ">= 3.1.1 || >= 3.4.0-dev || >= 3.5.0-dev"

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "ttypescript": "^1.5.5"
   },
   "devDependencies": {
-    "typescript": "3.4.0-dev.20190308"
+    "typescript": "^3.4.0-dev.20190309"
   },
   "peerDependencies": {
     "typescript": ">= 3.1.1 || >= 3.4.0-dev || >= 3.5.0-dev"

--- a/packages/mimir/test/no-inferred-empty-object/330.test.json
+++ b/packages/mimir/test/no-inferred-empty-object/330.test.json
@@ -1,0 +1,3 @@
+{
+  "typescriptVersion": "~3.3.0"
+}

--- a/packages/mimir/test/no-inferred-empty-object/default.test.json
+++ b/packages/mimir/test/no-inferred-empty-object/default.test.json
@@ -1,3 +1,3 @@
 {
-  "typescriptVersion": ">= 3.1.0"
+  "typescriptVersion": ">= 3.4.0"
 }

--- a/packages/mimir/test/no-inferred-empty-object/pre330.test.json
+++ b/packages/mimir/test/no-inferred-empty-object/pre330.test.json
@@ -1,0 +1,3 @@
+{
+  "typescriptVersion": "< 3.3.0"
+}

--- a/packages/mimir/test/no-inferred-empty-object/test.ts
+++ b/packages/mimir/test/no-inferred-empty-object/test.ts
@@ -235,6 +235,9 @@ new Promise<object>((resolve, reject) => {
 
 declare function myTagFn<T>(parts: TemplateStringsArray, ...values: T[]): string;
 declare function myOtherTag<T>(parts: TemplateStringsArray): T;
+declare function tag(parts: TemplateStringsArray): string;
+
+tag``;
 
 myTagFn``;
 myTagFn`${''}`;
@@ -327,3 +330,6 @@ overloaded();
 overloaded(1);
 overloaded(1, 2);
 overloaded('', '', '');
+
+declare let untyped: Function;
+untyped();

--- a/packages/mimir/test/no-inferred-empty-object/test.ts
+++ b/packages/mimir/test/no-inferred-empty-object/test.ts
@@ -305,3 +305,25 @@ unified2();
 const unified3 = Boolean() ? (a?: string) => undefined : <T = string>(param?: T) => param;
 unified3('2');
 unified3();
+
+declare const unified4: {(): void; (param?: string): string} | (<T>(param?: T) => T);
+unified4('1');
+unified4();
+
+declare const unified5: (<T>(a?: T) => T) | {(): void; (param?: string): string};
+unified5('1');
+unified5();
+
+declare const unified6: (<T = string>(a?: T) => T) | {(): void; (param?: string): string};
+unified6('1');
+unified6();
+
+declare function overloaded<T>(): void;
+declare function overloaded<T, U>(param: T): void;
+declare function overloaded<T, U, V, W = string>(a: T, b: T): void;
+declare function overloaded(a: string, b: string, c: string): void;
+
+overloaded();
+overloaded(1);
+overloaded(1, 2);
+overloaded('', '', '');

--- a/packages/mimir/test/no-inferred-empty-object/test.ts
+++ b/packages/mimir/test/no-inferred-empty-object/test.ts
@@ -251,3 +251,57 @@ interface SomeConstructor<T> {
 }
 declare const Ctor: SomeConstructor<any>;
 new Ctor(''); // don't crash here
+
+declare function pipe<A extends any[], B, C>(ab: (...args: A) => B, bc: (b: B) => C): (...args: A) => C;
+
+declare function list<T>(a?: T): T[];
+declare function list2<T = string>(a?: T): T[];
+declare function box<V>(x: V): { value: V };
+
+list();
+
+const listBox = pipe(list, box);
+listBox(1);
+listBox();
+
+const list2Box = pipe(list2, box);
+list2Box(1);
+list2Box();
+
+declare function pipe2<A, B, C, D>(ab: (a: A) => B, cd: (c: C) => D): (a?: [A, C] | [A]) => [B, D];
+
+const listList = pipe2(list, list);
+listList([1, '2']);
+listList([1]);
+listList();
+
+const list2List = pipe2(list, list2);
+list2List([1, '2']);
+list2List([1]);
+list2List();
+
+function pipe3<A, B, C, D>(ab: (a?: A) => B, cd: (c?: C) => D) {
+    return (a?: A, c?: C) => [ab(a), cd(c)] as const;
+}
+
+const listList2 = pipe3(list, list);
+listList2(1, '2');
+listList2(1);
+listList2();
+
+declare function pipe4<A extends any[], B, C>(ab: (...args: A) => B, bc?: (b: B) => C): (...args: A) => C;
+
+const listNone = pipe4(list);
+listNone(1);
+
+const unified = Boolean() ? <T>(param?: T) => param : () => undefined;
+unified('1');
+unified();
+
+const unified2 = Boolean() ? (a?: string) => undefined : <T>(param?: T) => param;
+unified2('2');
+unified2();
+
+const unified3 = Boolean() ? (a?: string) => undefined : <T = string>(param?: T) => param;
+unified3('2');
+unified3();

--- a/yarn.lock
+++ b/yarn.lock
@@ -4610,10 +4610,10 @@ tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-0.14.5.tgz#5ae68177f192d4456269d108afa93ff8743f4f64"
   integrity sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=
 
-typescript@3.4.0-dev.20190308:
-  version "3.4.0-dev.20190308"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.4.0-dev.20190308.tgz#fc530477ca420ea7aec2628489b825bd8297cde9"
-  integrity sha512-0TqxMnTl1qH9YWctV2vYH7d3eoAEHolnvbps6BHVWWATuAZd+/8Nd8+yZ6gm0oK3/6CCOrcqsiNS3eBT9VdS2A==
+typescript@^3.4.0-dev.20190309:
+  version "3.4.0-dev.20190309"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.4.0-dev.20190309.tgz#3e91ccf4c29f096c6afacc3455c5df0a68faf650"
+  integrity sha512-m/3xJgKDfgwgUbrmZsPMpJR6Nnka0yWuQKHHvR1ZGwI54LVbu+QESg0sKBDxgNwC2f7eDMDKgipaZiFWntPa0g==
 
 uglify-js@^3.1.4:
   version "3.4.9"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4610,10 +4610,10 @@ tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-0.14.5.tgz#5ae68177f192d4456269d108afa93ff8743f4f64"
   integrity sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=
 
-typescript@^3.4.0-dev.20190309:
-  version "3.4.0-dev.20190309"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.4.0-dev.20190309.tgz#3e91ccf4c29f096c6afacc3455c5df0a68faf650"
-  integrity sha512-m/3xJgKDfgwgUbrmZsPMpJR6Nnka0yWuQKHHvR1ZGwI54LVbu+QESg0sKBDxgNwC2f7eDMDKgipaZiFWntPa0g==
+typescript@3.4.0-dev.20190310:
+  version "3.4.0-dev.20190310"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.4.0-dev.20190310.tgz#0708ea8bff196a966719143d593c26ace062bd7f"
+  integrity sha512-g00ai4cac5BzhMZ9oXHjHYMZRWrfQRviBA5hNaDez04KE8gnNtKWK+PbD8kpPHwQt1TEsOQ679gpO1HMbdNOYQ==
 
 uglify-js@^3.1.4:
   version "3.4.9"


### PR DESCRIPTION
#### Checklist

- [x] Fixes: #564
- [x] Added or updated tests / baselines

#### Overview of change 
* fixed a crash when calling `pipe`-like functions
* collect type parameters from inferred signatures
* avoid printing call signature if all type parameters have a default
* added additional tests for function  type unification