### PR TITLE
Lazy update of Program

### DIFF
--- a/baselines/packages/wotan/api/src/linter.d.ts
+++ b/baselines/packages/wotan/api/src/linter.d.ts
@@ -1,16 +1,16 @@
 import * as ts from 'typescript';
 import { Finding, EffectiveConfiguration, LintAndFixFileResult, Severity, MessageHandler, AbstractProcessor, DeprecationHandler, FindingFilterFactory } from '@fimbul/ymir';
 import { RuleLoader } from './services/rule-loader';
-export interface UpdateFileResult {
-    file: ts.SourceFile;
-    program?: ts.Program;
-}
 export interface LinterOptions {
     reportUselessDirectives?: Severity;
 }
-export declare type UpdateFileCallback = (content: string, range: ts.TextChangeRange) => UpdateFileResult | undefined;
+export interface ProgramFactory {
+    getCompilerOptions(): ts.CompilerOptions;
+    getProgram(): ts.Program;
+}
+export declare type UpdateFileCallback = (content: string, range: ts.TextChangeRange) => ts.SourceFile | undefined;
 export declare class Linter {
     constructor(ruleLoader: RuleLoader, logger: MessageHandler, deprecationHandler: DeprecationHandler, filterFactory: FindingFilterFactory);
-    lintFile(file: ts.SourceFile, config: EffectiveConfiguration, program?: ts.Program, options?: LinterOptions): ReadonlyArray<Finding>;
-    lintAndFix(file: ts.SourceFile, content: string, config: EffectiveConfiguration, updateFile: UpdateFileCallback, iterations?: number, program?: ts.Program, processor?: AbstractProcessor, options?: LinterOptions): LintAndFixFileResult;
+    lintFile(file: ts.SourceFile, config: EffectiveConfiguration, programOrFactory?: ProgramFactory | ts.Program, options?: LinterOptions): ReadonlyArray<Finding>;
+    lintAndFix(file: ts.SourceFile, content: string, config: EffectiveConfiguration, updateFile: UpdateFileCallback, iterations?: number, programFactory?: ProgramFactory, processor?: AbstractProcessor, options?: LinterOptions): LintAndFixFileResult;
 }

--- a/baselines/packages/ymir/api/src/index.d.ts
+++ b/baselines/packages/ymir/api/src/index.d.ts
@@ -46,38 +46,37 @@ export declare type Severity = 'error' | 'warning' | 'suggestion';
 export interface RuleConstructor<T extends RuleContext = RuleContext> {
     readonly requiresTypeInformation: boolean;
     readonly deprecated?: boolean | string;
-    supports?: RuleSupportsPredicate;
+    supports?: RulePredicate;
     new (context: T): AbstractRule;
 }
-export interface RuleSupportsContext {
+export interface RulePredicateContext {
     readonly program?: ts.Program;
+    readonly compilerOptions?: ts.CompilerOptions;
     readonly settings: Settings;
     readonly options: {} | null | undefined;
 }
-export interface RuleContext {
-    readonly program?: ts.Program;
+export interface RuleContext extends RulePredicateContext {
     readonly sourceFile: ts.SourceFile;
-    readonly settings: Settings;
-    readonly options: {} | null | undefined;
     addFinding(start: number, end: number, message: string, fix?: Replacement | ReadonlyArray<Replacement>): void;
     getFlatAst(): ReadonlyArray<ts.Node>;
     getWrappedAst(): WrappedAst;
 }
 export interface TypedRuleContext extends RuleContext {
     readonly program: ts.Program;
+    readonly compilerOptions: ts.CompilerOptions;
 }
 export declare type Settings = ReadonlyMap<string, {} | null | undefined>;
-export declare function predicate(check: RuleSupportsPredicate): (target: typeof AbstractRule) => void;
+export declare function predicate(check: RulePredicate): (target: typeof AbstractRule) => void;
 export declare function typescriptOnly(target: typeof AbstractRule): void;
 export declare function excludeDeclarationFiles(target: typeof AbstractRule): void;
 export declare function requireLibraryFile(fileName: string): (target: typeof TypedRule) => void;
 export declare function requiresCompilerOption(option: BooleanCompilerOptions): (target: typeof TypedRule) => void;
-export declare type RuleSupportsPredicate = (sourceFile: ts.SourceFile, context: RuleSupportsContext) => boolean | string;
+export declare type RulePredicate = (sourceFile: ts.SourceFile, context: RulePredicateContext) => boolean | string;
 export declare abstract class AbstractRule {
     readonly context: RuleContext;
     static readonly requiresTypeInformation: boolean;
     static deprecated: boolean | string;
-    static supports?: RuleSupportsPredicate;
+    static supports?: RulePredicate;
     static validateConfig?(config: any): string[] | string | undefined;
     readonly sourceFile: ts.SourceFile;
     readonly program: ts.Program | undefined;

--- a/docs/writing-rules.md
+++ b/docs/writing-rules.md
@@ -232,6 +232,13 @@ Replacement.replace(start, end, '{}');
 ];
 ```
 
+## More Performance Advice
+
+After fixes are applied, the `Program` needs to be updated before type information is available and up to date for the next rule.
+To avoid unnecessary updates to the `Program` Wotan tries to defer that task for as long as possible. This is done by making `AbstractRule#program`, `TypedRule#checker` and `RuleContext#program` get accessors that update the program on first use.
+Therefore try to avoid accessing these properties if there are other conditions you could check first.
+That's why `RuleContext` has a member `compilerOptions` that contains the `CompilerOptions` currently in use. Using this property doesn't cause an update of the `Program`. It's a cheaper way to check if type information would be availabe or which compiler options are enabled.
+
 ## Testing
 
 Before we throw our rule at our and other people's code, we should make sure it works as intended and doesn't destroy the code it's intended to make better.

--- a/packages/bifrost/test/rule.spec.ts
+++ b/packages/bifrost/test/rule.spec.ts
@@ -234,7 +234,7 @@ test('correctly applies rule when wrapped for TSLint', (t) => {
         public apply() {
             t.is(this.context.options, 'foo');
             if (this.context.program !== undefined)
-                t.is(this.context.program, <any>'bar');
+                t.is(this.context.program, <any>'');
             this.addFinding(0, 0, 'test message');
         }
     }
@@ -248,7 +248,7 @@ test('correctly applies rule when wrapped for TSLint', (t) => {
         [],
     );
     t.deepEqual(
-        rule.applyWithProgram(jsSourceFile, <any>'bar'),
+        rule.applyWithProgram(jsSourceFile, <any>''),
         [],
     );
     const tsSourceFile = ts.createSourceFile('foo.ts', ';', ts.ScriptTarget.ESNext);
@@ -257,7 +257,7 @@ test('correctly applies rule when wrapped for TSLint', (t) => {
         [new TSLint.RuleFailure(tsSourceFile, 0, 0, 'test message', 'some-name')],
     );
     t.deepEqual(
-        rule.applyWithProgram(tsSourceFile, <any>'bar'),
+        rule.applyWithProgram(tsSourceFile, <any>''),
         [new TSLint.RuleFailure(tsSourceFile, 0, 0, 'test message', 'some-name')],
     );
 
@@ -279,7 +279,7 @@ test('correctly applies rule when wrapped for TSLint', (t) => {
         {ruleArguments: ['foo', 'bar'], disabledIntervals: [], ruleName: 'some-other-name', ruleSeverity: 'error'},
     );
     t.deepEqual(
-        rule.applyWithProgram(tsSourceFile, <any>'bar'),
+        rule.applyWithProgram(tsSourceFile, <any>''),
         [new TSLint.RuleFailure(tsSourceFile, 0, 0, 'message', 'some-other-name', [TSLint.Replacement.replaceFromTo(0, 1, 'x')])],
     );
 });

--- a/packages/bifrost/test/rule.spec.ts
+++ b/packages/bifrost/test/rule.spec.ts
@@ -2,7 +2,7 @@ import test from 'ava';
 import * as TSLint from 'tslint';
 import { wrapTslintRule, wrapRuleForTslint } from '../src';
 import * as ts from 'typescript';
-import { RuleContext, Replacement, AbstractRule, TypedRule, typescriptOnly } from '@fimbul/ymir';
+import { RuleContext, Replacement, AbstractRule, TypedRule, typescriptOnly, predicate } from '@fimbul/ymir';
 import { convertAst } from 'tsutils';
 
 test('correctly wraps TSLint rule', (t) => {
@@ -266,8 +266,10 @@ test('correctly applies rule when wrapped for TSLint', (t) => {
         [],
     );
 
+    @predicate((_, {program, compilerOptions}) => program!.getCompilerOptions() === compilerOptions)
     class MyTypedRule extends TypedRule {
         public apply() {
+            t.is(this.program.getCompilerOptions(), this.context.compilerOptions);
             t.deepEqual(this.context.getFlatAst(), convertAst(tsSourceFile).flat);
             t.deepEqual(this.context.getWrappedAst(), convertAst(tsSourceFile).wrapped);
             t.deepEqual(this.context.options, ['foo', 'bar']);
@@ -279,7 +281,7 @@ test('correctly applies rule when wrapped for TSLint', (t) => {
         {ruleArguments: ['foo', 'bar'], disabledIntervals: [], ruleName: 'some-other-name', ruleSeverity: 'error'},
     );
     t.deepEqual(
-        rule.applyWithProgram(tsSourceFile, <any>''),
+        rule.applyWithProgram(tsSourceFile, <any>{getCompilerOptions() { return this; }}),
         [new TSLint.RuleFailure(tsSourceFile, 0, 0, 'message', 'some-other-name', [TSLint.Replacement.replaceFromTo(0, 1, 'x')])],
     );
 });

--- a/packages/mimir/src/rules/no-duplicate-case.ts
+++ b/packages/mimir/src/rules/no-duplicate-case.ts
@@ -74,9 +74,9 @@ export class Rule extends AbstractRule {
         if (node.kind === ts.SyntaxKind.FalseKeyword)
             return [formatPrimitive(prefixFn(false))];
 
-        if (this.program === undefined || !isStrictCompilerOptionEnabled(this.program.getCompilerOptions(), 'strictNullChecks'))
+        if (this.context.compilerOptions === undefined || !isStrictCompilerOptionEnabled(this.context.compilerOptions, 'strictNullChecks'))
             return [];
-        const checker = this.program.getTypeChecker();
+        const checker = this.program!.getTypeChecker();
         let type = checker.getTypeAtLocation(node);
         type = checker.getBaseConstraintOfType(type) || type;
         const result = new Set<string>();

--- a/packages/mimir/src/rules/no-useless-assertion.ts
+++ b/packages/mimir/src/rules/no-useless-assertion.ts
@@ -25,7 +25,7 @@ const FAIL_DEFINITE_ASSIGNMENT = 'This assertion is unnecessary as it has no eff
 @excludeDeclarationFiles
 @typescriptOnly
 export class Rule extends TypedRule {
-    private strictNullChecks = isStrictCompilerOptionEnabled(this.program.getCompilerOptions(), 'strictNullChecks');
+    private strictNullChecks = isStrictCompilerOptionEnabled(this.context.compilerOptions, 'strictNullChecks');
 
     public apply(): void {
         for (const node of this.context.getFlatAst()) {
@@ -50,7 +50,7 @@ export class Rule extends TypedRule {
         // compiler already emits an error for definite assignment assertions on ambient or initialized variables
         if (node.exclamationToken !== undefined &&
             node.initializer === undefined && (
-                !isStrictCompilerOptionEnabled(this.program.getCompilerOptions(), 'strictNullChecks') ||
+                !isStrictCompilerOptionEnabled(this.context.compilerOptions, 'strictNullChecks') ||
                 getNullableFlags(this.checker.getTypeAtLocation(node.name), true) & ts.TypeFlags.Undefined // type does not allow undefined
             ))
             this.addFinding(
@@ -67,7 +67,7 @@ export class Rule extends TypedRule {
             node.initializer === undefined &&
             !hasModifier(node.modifiers, ts.SyntaxKind.AbstractKeyword) && (
                 node.name.kind !== ts.SyntaxKind.Identifier || // properties with string or computed name are not checked
-                !isStrictCompilerOptionEnabled(this.program.getCompilerOptions(), 'strictPropertyInitialization') ||
+                !isStrictCompilerOptionEnabled(this.context.compilerOptions, 'strictPropertyInitialization') ||
                 getNullableFlags(this.checker.getTypeAtLocation(node), true) & ts.TypeFlags.Undefined // type does not allow undefined
             ))
             this.addFinding(

--- a/packages/mimir/src/rules/no-useless-initializer.ts
+++ b/packages/mimir/src/rules/no-useless-initializer.ts
@@ -48,9 +48,9 @@ export class Rule extends AbstractRule {
     }
 
     private checkObjectDestructuring(node: ts.ObjectLiteralExpression) {
-        if (this.program === undefined || !isStrictCompilerOptionEnabled(this.program.getCompilerOptions(), 'strictNullChecks'))
+        if (this.context.compilerOptions === undefined || !isStrictCompilerOptionEnabled(this.context.compilerOptions, 'strictNullChecks'))
             return;
-        const checker = this.program.getTypeChecker();
+        const checker = this.program!.getTypeChecker();
         for (const property of node.properties) {
             let name: ts.Identifier;
             let errorNode: ts.Expression;
@@ -81,9 +81,9 @@ export class Rule extends AbstractRule {
     }
 
     private checkBindingPattern(node: ts.BindingPattern, propNames: typeof getObjectPropertyName) {
-        if (this.program === undefined || !isStrictCompilerOptionEnabled(this.program.getCompilerOptions(), 'strictNullChecks'))
+        if (this.context.compilerOptions === undefined || !isStrictCompilerOptionEnabled(this.context.compilerOptions, 'strictNullChecks'))
             return;
-        const checker = this.program.getTypeChecker();
+        const checker = this.program!.getTypeChecker();
         let type: ts.Type | undefined;
         for (let i = 0; i < node.elements.length; ++i) {
             const element = node.elements[i];

--- a/packages/mimir/src/rules/no-useless-predicate.ts
+++ b/packages/mimir/src/rules/no-useless-predicate.ts
@@ -78,7 +78,7 @@ const predicates: Record<string, TypePredicate> = {
 
 @excludeDeclarationFiles
 export class Rule extends TypedRule {
-    private strictNullChecks = isStrictCompilerOptionEnabled(this.program.getCompilerOptions(), 'strictNullChecks');
+    private strictNullChecks = isStrictCompilerOptionEnabled(this.context.compilerOptions, 'strictNullChecks');
 
     public apply() {
         for (const node of this.context.getFlatAst()) {

--- a/packages/mimir/src/rules/no-useless-strict.ts
+++ b/packages/mimir/src/rules/no-useless-strict.ts
@@ -13,11 +13,12 @@ const enum Reason {
 
 @excludeDeclarationFiles
 export class Rule extends AbstractRule {
-    private strictFile = this.program !== undefined && isStrictCompilerOptionEnabled(this.program.getCompilerOptions(), 'alwaysStrict')
-        ? Reason.Option
-        : ts.isExternalModule(this.sourceFile)
-            ? Reason.Module
-            : undefined;
+    private strictFile =
+        this.context.compilerOptions !== undefined && isStrictCompilerOptionEnabled(this.context.compilerOptions, 'alwaysStrict')
+            ? Reason.Option
+            : ts.isExternalModule(this.sourceFile)
+                ? Reason.Module
+                : undefined;
 
     public apply() {
         const re = /(['"])use strict\1/g;

--- a/packages/mimir/src/rules/prefer-for-of.ts
+++ b/packages/mimir/src/rules/prefer-for-of.ts
@@ -65,7 +65,7 @@ export class Rule extends TypedRule {
     }
 
     private isIterationProtocolAvailable(): boolean {
-        return this.sourceFile.languageVersion >= ts.ScriptTarget.ES2015 || this.program.getCompilerOptions().downlevelIteration === true;
+        return this.sourceFile.languageVersion >= ts.ScriptTarget.ES2015 || this.context.compilerOptions.downlevelIteration === true;
     }
 
     private isArrayLike(type: ts.Type): boolean {
@@ -87,7 +87,7 @@ export class Rule extends TypedRule {
     private isDeclaredInDefaultLib(node: ts.Node): boolean {
         // we assume it's the global array type if it comes from any lib.xxx.d.ts file
         return path.normalize(path.dirname(node.getSourceFile().fileName))
-            === path.dirname(ts.getDefaultLibFilePath(this.program.getCompilerOptions()));
+            === path.dirname(ts.getDefaultLibFilePath(this.context.compilerOptions));
     }
 
     private isIterable(type: ts.Type, node: ts.Expression): boolean {

--- a/packages/mimir/src/rules/typecheck.ts
+++ b/packages/mimir/src/rules/typecheck.ts
@@ -5,7 +5,7 @@ import { isCompilerOptionEnabled } from 'tsutils';
 export class Rule extends TypedRule {
     public apply() {
         this.program.getSemanticDiagnostics(this.sourceFile).forEach(this.addDiagnostic, this);
-        if (isCompilerOptionEnabled(this.program.getCompilerOptions(), 'declaration'))
+        if (isCompilerOptionEnabled(this.context.compilerOptions, 'declaration'))
             this.program.getDeclarationDiagnostics(this.sourceFile).forEach(this.addDiagnostic, this);
     }
 

--- a/packages/wotan/language-service/index.ts
+++ b/packages/wotan/language-service/index.ts
@@ -142,7 +142,7 @@ export class LanguageServiceInterceptor implements PartialLanguageServiceInterce
         if (effectiveConfig === undefined)
             return [];
         const linter = container.get(Linter);
-        return linter.lintFile(file, effectiveConfig, program, {
+        return linter.lintFile(file, effectiveConfig, () => program, {
             reportUselessDirectives: globalConfig.reportUselessDirectives
                 ? globalConfig.reportUselessDirectives === true
                     ? 'error'

--- a/packages/wotan/language-service/index.ts
+++ b/packages/wotan/language-service/index.ts
@@ -142,7 +142,7 @@ export class LanguageServiceInterceptor implements PartialLanguageServiceInterce
         if (effectiveConfig === undefined)
             return [];
         const linter = container.get(Linter);
-        return linter.lintFile(file, effectiveConfig, () => program, {
+        return linter.lintFile(file, effectiveConfig, program, {
             reportUselessDirectives: globalConfig.reportUselessDirectives
                 ? globalConfig.reportUselessDirectives === true
                     ? 'error'

--- a/packages/wotan/src/linter.ts
+++ b/packages/wotan/src/linter.ts
@@ -27,8 +27,11 @@ export interface LinterOptions {
     reportUselessDirectives?: Severity;
 }
 
+/** This factory is used to lazily create or update the Program only when necessary. */
 export interface ProgramFactory {
+    /** Get the CompilerOptions used to create the Program. */
     getCompilerOptions(): ts.CompilerOptions;
+    /** Returns the Program after  creating or updating it if necessary. */
     getProgram(): ts.Program;
 }
 

--- a/packages/wotan/src/linter.ts
+++ b/packages/wotan/src/linter.ts
@@ -31,7 +31,7 @@ export interface LinterOptions {
 export interface ProgramFactory {
     /** Get the CompilerOptions used to create the Program. */
     getCompilerOptions(): ts.CompilerOptions;
-    /** Returns the Program after  creating or updating it if necessary. */
+    /** This method is called to retrieve the Program on the first use. It should create or update the Program if necessary. */
     getProgram(): ts.Program;
 }
 

--- a/packages/wotan/src/runner.ts
+++ b/packages/wotan/src/runner.ts
@@ -13,7 +13,7 @@ import {
 import * as path from 'path';
 import * as ts from 'typescript';
 import * as glob from 'glob';
-import { unixifyPath, hasSupportedExtension, addUnique, flatMap, createParseConfigHost, hasParseErrors } from './utils';
+import { unixifyPath, hasSupportedExtension, addUnique, flatMap, createParseConfigHost, hasParseErrors, invertChangeRange } from './utils';
 import { Minimatch, IMinimatch } from 'minimatch';
 import { ProcessorLoader } from './services/processor-loader';
 import { injectable } from 'inversify';
@@ -88,6 +88,15 @@ export class Runner {
         for (let {files, program} of
             this.getFilesAndProgram(options.project, options.files, options.exclude, processorHost, options.references)
         ) {
+            let invalidatedProgram = false;
+            function getProgram() {
+                if (invalidatedProgram) {
+                    log('updating invalidated program');
+                    program = processorHost.updateProgram(program);
+                    invalidatedProgram = false;
+                }
+                return program;
+            }
             for (const file of files) {
                 if (options.config === undefined)
                     config = this.configManager.find(file);
@@ -106,12 +115,20 @@ export class Runner {
                         originalContent,
                         effectiveConfig,
                         (content, range) => {
-                            let error;
-                            ({sourceFile, program, error} = processorHost.updateSourceFile(sourceFile, program, content, range));
-                            return error ? undefined : {program, file: sourceFile};
+                            invalidatedProgram = true;
+                            const oldContent = sourceFile.text;
+                            sourceFile = ts.updateSourceFile(sourceFile, content, range);
+                            const hasErrors = hasParseErrors(sourceFile);
+                            if (hasErrors) {
+                                log("Autofixing caused syntax errors in '%s', rolling back", sourceFile.fileName);
+                                sourceFile = ts.updateSourceFile(sourceFile, oldContent, invertChangeRange(range));
+                            }
+                            // either way we need to store the new SourceFile as the old one is now corrupted
+                            processorHost.updateSourceFile(sourceFile);
+                            return hasErrors ? undefined : sourceFile;
                         },
                         fix === true ? undefined : fix,
-                        program,
+                        getProgram,
                         mapped === undefined ? undefined : mapped.processor,
                         linterOptions,
                     );
@@ -120,7 +137,7 @@ export class Runner {
                         findings: this.linter.getFindings(
                             sourceFile,
                             effectiveConfig,
-                            program,
+                            getProgram,
                             mapped === undefined ? undefined : mapped.processor,
                             linterOptions,
                         ),
@@ -189,7 +206,7 @@ export class Runner {
                             // Note: 'sourceFile' shouldn't be used after this as it contains invalid code
                             return;
                         }
-                        return {file: sourceFile};
+                        return sourceFile;
                     },
                     fix === true ? undefined : fix,
                     undefined,

--- a/packages/wotan/test/linter.spec.ts
+++ b/packages/wotan/test/linter.spec.ts
@@ -194,18 +194,38 @@ test('Linter', (t) => {
                 },
                 {
                     getCompilerOptions() {
-                        if (getCompilerOptionsCalled)
-                            t.fail("should not call 'getCompilerOptions' multiple times");
+                        t.is(getCompilerOptionsCalled, false, 'should not be called multiple times');
                         getCompilerOptionsCalled = true;
                         return program.getCompilerOptions();
                     },
                     getProgram() {
-                        if (getProgramCalled)
-                            t.fail("should not call 'getProgram' multiple times");
+                        t.is(getProgramCalled, false, 'should not be called multiple times');
                         getProgramCalled = true;
                         return program;
                     },
                 },
+            ),
+            [{
+                ruleName: 'rule-name',
+                fix: undefined,
+                message: 'true',
+                severity: 'error',
+                start: {position: 0, line: 0, character: 0},
+                end: {position: 0, line: 0, character: 0},
+            }],
+        );
+        t.is(warnings.length, 5);
+
+        t.deepEqual<ReadonlyArray<Finding>>(
+            linter.lintFile(
+                sourceFile,
+                {
+                    settings: new Map(),
+                    rules: new Map<string, EffectiveConfiguration.RuleConfig>([
+                        ['rule-name', {severity: 'error', rulesDirectories: undefined, options: undefined, rule: 'program-access'}],
+                    ]),
+                },
+                program,
             ),
             [{
                 ruleName: 'rule-name',

--- a/packages/wotan/test/linter.spec.ts
+++ b/packages/wotan/test/linter.spec.ts
@@ -183,7 +183,8 @@ test('Linter', (t) => {
     t.is(warnings[5], "Rule 'my/typed' requires type information.");
 
     function lintWithProgram(file: ts.SourceFile, options: ts.CompilerOptions, config: EffectiveConfiguration) {
-        return linter.lintFile(file, config, createFakeProgram(file, options));
+        const program = createFakeProgram(file, options);
+        return linter.lintFile(file, config, () => program);
     }
 
     t.deepEqual<ReadonlyArray<Finding>>(

--- a/packages/wotan/test/linter.spec.ts
+++ b/packages/wotan/test/linter.spec.ts
@@ -183,8 +183,7 @@ test('Linter', (t) => {
     t.is(warnings[5], "Rule 'my/typed' requires type information.");
 
     function lintWithProgram(file: ts.SourceFile, options: ts.CompilerOptions, config: EffectiveConfiguration) {
-        const program = createFakeProgram(file, options);
-        return linter.lintFile(file, config, () => program);
+        return linter.lintFile(file, config, createFakeProgram(file, options));
     }
 
     t.deepEqual<ReadonlyArray<Finding>>(

--- a/packages/ymir/src/index.ts
+++ b/packages/ymir/src/index.ts
@@ -79,7 +79,7 @@ export type Severity = 'error' | 'warning' | 'suggestion';
 export interface RuleConstructor<T extends RuleContext = RuleContext> {
     readonly requiresTypeInformation: boolean;
     readonly deprecated?: boolean | string;
-    supports?: RuleSupportsPredicate;
+    supports?: RulePredicate;
     new(context: T): AbstractRule;
 }
 
@@ -104,13 +104,13 @@ export interface TypedRuleContext extends RuleContext {
 
 export type Settings = ReadonlyMap<string, {} | null | undefined>;
 
-export function predicate(check: RuleSupportsPredicate) {
+export function predicate(check: RulePredicate) {
     return (target: typeof AbstractRule) => {
         target.supports = combinePredicates(target.supports, check);
     };
 }
 
-function combinePredicates(existing: RuleSupportsPredicate | undefined, additonal: RuleSupportsPredicate): RuleSupportsPredicate {
+function combinePredicates(existing: RulePredicate | undefined, additonal: RulePredicate): RulePredicate {
     if (existing === undefined)
         return additonal;
     return (sourceFile, context) => {
@@ -151,12 +151,12 @@ export function requiresCompilerOption(option: BooleanCompilerOptions) {
 }
 
 /** @returns `true`, `false` or a reason */
-export type RuleSupportsPredicate = (sourceFile: ts.SourceFile, context: RulePredicateContext) => boolean | string;
+export type RulePredicate = (sourceFile: ts.SourceFile, context: RulePredicateContext) => boolean | string;
 
 export abstract class AbstractRule {
     public static readonly requiresTypeInformation: boolean = false;
     public static deprecated: boolean | string = false;
-    public static supports?: RuleSupportsPredicate = undefined;
+    public static supports?: RulePredicate = undefined;
     public static validateConfig?(config: any): string[] | string | undefined;
 
     public readonly sourceFile: ts.SourceFile;

--- a/packages/ymir/src/index.ts
+++ b/packages/ymir/src/index.ts
@@ -161,11 +161,13 @@ export abstract class AbstractRule {
     public static validateConfig?(config: any): string[] | string | undefined;
 
     public readonly sourceFile: ts.SourceFile;
-    public readonly program: ts.Program | undefined;
+
+    public get program() {
+        return this.context.program;
+    }
 
     constructor(public readonly context: RuleContext) {
         this.sourceFile = context.sourceFile;
-        this.program = context.program;
     }
 
     public abstract apply(): void;


### PR DESCRIPTION
#### Checklist

- [x] Fixes: #574
- [x] Added or updated tests / baselines
- [x] Documentation update

#### Overview of change

After fixing the Program is not updated immediately. Instead this is done just in time on the first access.
That means fixing a Program with only syntactic rules enabled never updates the Program.

To avoid accessing CompilerOptions via Program there is now a new property on RuleContext.
