### PR TITLE
Drop node6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,19 +79,19 @@ jobs:
     <<: *base
   test@3.2:
     docker:
-      - image: circleci/node:6@sha256:a6999483db134741b4b4cd7bf79a70c58168b58a7a42d408a76f2250a582ab57
+      - image: circleci/node:8@sha256:fe8a2bc8b6cb04f910328b732d63ad8efeb7e2ce13f083f638a6fa12174937c8
     environment:
       typescriptVersion: "3.2"
     <<: *base
   test@3.3:
     docker:
-      - image: circleci/node:8@sha256:fe8a2bc8b6cb04f910328b732d63ad8efeb7e2ce13f083f638a6fa12174937c8
+      - image: circleci/node:10@sha256:4f49582e764b967d663482206ab88dc4e5fd84f153c1bb1350edd6125d123882
     environment:
       typescriptVersion: "3.3"
     <<: *base
   test@3.4:
     docker:
-      - image: circleci/node:10@sha256:4f49582e764b967d663482206ab88dc4e5fd84f153c1bb1350edd6125d123882
+      - image: circleci/node:11@sha256:70cf6e353c781d315ce71ed4e81c3ec04c8be50fccdf00488c844434de59aba1
     environment:
       typescriptVersion: "3.4"
     <<: *base

--- a/tsconfig-base.json
+++ b/tsconfig-base.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    "target": "es6",
-    "lib": ["es2016"],
+    "target": "es2017",
+    "lib": ["es2017"],
     "module": "commonjs",
     "sourceMap": true,
     "importHelpers": true,


### PR DESCRIPTION
EOL of Node.js v6 is at the end of the month and some dependencies already start dropping support for it.