### PR TITLE
no-uninferred-type-parameter: handle higher order constructor inference

### DIFF
--- a/baselines/packages/mimir/test/no-uninferred-type-parameter/330/test.ts.lint
+++ b/baselines/packages/mimir/test/no-uninferred-type-parameter/330/test.ts.lint
@@ -417,3 +417,6 @@ const List = toConstructor(list);
 new List(1);
 new List();
 new List<number>();
+
+const List2 = toConstructor(list2);
+new List2();

--- a/baselines/packages/mimir/test/no-uninferred-type-parameter/330/test.ts.lint
+++ b/baselines/packages/mimir/test/no-uninferred-type-parameter/330/test.ts.lint
@@ -410,3 +410,10 @@ function f<T extends typeof overloaded, U extends typeof unified5, V extends typ
 
 declare let untyped: Function;
 untyped();
+
+declare function toConstructor<P extends unknown[], R>(fn: (...params: P) => R): new (...params: P) => R;
+
+const List = toConstructor(list);
+new List(1);
+new List();
+new List<number>();

--- a/baselines/packages/mimir/test/no-uninferred-type-parameter/340/test.ts.lint
+++ b/baselines/packages/mimir/test/no-uninferred-type-parameter/340/test.ts.lint
@@ -419,3 +419,6 @@ const List = toConstructor(list);
 new List(1);
 new List();
 new List<number>();
+
+const List2 = toConstructor(list2);
+new List2();

--- a/baselines/packages/mimir/test/no-uninferred-type-parameter/340/test.ts.lint
+++ b/baselines/packages/mimir/test/no-uninferred-type-parameter/340/test.ts.lint
@@ -412,3 +412,10 @@ function f<T extends typeof overloaded, U extends typeof unified5, V extends typ
 
 declare let untyped: Function;
 untyped();
+
+declare function toConstructor<P extends unknown[], R>(fn: (...params: P) => R): new (...params: P) => R;
+
+const List = toConstructor(list);
+new List(1);
+new List();
+new List<number>();

--- a/baselines/packages/mimir/test/no-uninferred-type-parameter/default/test.ts.lint
+++ b/baselines/packages/mimir/test/no-uninferred-type-parameter/default/test.ts.lint
@@ -418,3 +418,6 @@ new List(1);
 new List();
 ~~~~~~~~~~  [error no-uninferred-type-parameter: TypeParameter 'T' is inferred as 'unknown'. Consider adding type arguments to the call.]
 new List<number>();
+
+const List2 = toConstructor(list2);
+new List2();

--- a/baselines/packages/mimir/test/no-uninferred-type-parameter/default/test.ts.lint
+++ b/baselines/packages/mimir/test/no-uninferred-type-parameter/default/test.ts.lint
@@ -410,3 +410,11 @@ function f<T extends typeof overloaded, U extends typeof unified5, V extends typ
 
 declare let untyped: Function;
 untyped();
+
+declare function toConstructor<P extends unknown[], R>(fn: (...params: P) => R): new (...params: P) => R;
+
+const List = toConstructor(list);
+new List(1);
+new List();
+~~~~~~~~~~  [error no-uninferred-type-parameter: TypeParameter 'T' is inferred as 'unknown'. Consider adding type arguments to the call.]
+new List<number>();

--- a/baselines/packages/mimir/test/no-uninferred-type-parameter/pre330/test.ts.lint
+++ b/baselines/packages/mimir/test/no-uninferred-type-parameter/pre330/test.ts.lint
@@ -406,3 +406,10 @@ function f<T extends typeof overloaded, U extends typeof unified5, V extends typ
 
 declare let untyped: Function;
 untyped();
+
+declare function toConstructor<P extends unknown[], R>(fn: (...params: P) => R): new (...params: P) => R;
+
+const List = toConstructor(list);
+new List(1);
+new List();
+new List<number>();

--- a/baselines/packages/mimir/test/no-uninferred-type-parameter/pre330/test.ts.lint
+++ b/baselines/packages/mimir/test/no-uninferred-type-parameter/pre330/test.ts.lint
@@ -413,3 +413,6 @@ const List = toConstructor(list);
 new List(1);
 new List();
 new List<number>();
+
+const List2 = toConstructor(list2);
+new List2();

--- a/packages/mimir/test/no-uninferred-type-parameter/test.ts
+++ b/packages/mimir/test/no-uninferred-type-parameter/test.ts
@@ -357,3 +357,6 @@ const List = toConstructor(list);
 new List(1);
 new List();
 new List<number>();
+
+const List2 = toConstructor(list2);
+new List2();

--- a/packages/mimir/test/no-uninferred-type-parameter/test.ts
+++ b/packages/mimir/test/no-uninferred-type-parameter/test.ts
@@ -350,3 +350,10 @@ function f<T extends typeof overloaded, U extends typeof unified5, V extends typ
 
 declare let untyped: Function;
 untyped();
+
+declare function toConstructor<P extends unknown[], R>(fn: (...params: P) => R): new (...params: P) => R;
+
+const List = toConstructor(list);
+new List(1);
+new List();
+new List<number>();


### PR DESCRIPTION
#### Checklist

- [x] Fixes: #605 
- [x] Added or updated tests / baselines
