### PR TITLE
update tsutils to latest version

### DIFF
--- a/baselines/packages/mimir/test/delete-only-optional-property/default/test.ts.lint
+++ b/baselines/packages/mimir/test/delete-only-optional-property/default/test.ts.lint
@@ -55,7 +55,7 @@ delete optional.d;
 delete [].length;
 ~~~~~~~~~~~~~~~~  [error delete-only-optional-property: Only 'delete' optional properties. Property 'length' is required.]
 delete [][Symbol.iterator];
-~~~~~~~~~~~~~~~~~~~~~~~~~~  [error delete-only-optional-property: Only 'delete' optional properties. Property 'Symbol.iterator' is required.]
+~~~~~~~~~~~~~~~~~~~~~~~~~~  [error delete-only-optional-property: Only 'delete' optional properties. Property '[Symbol.iterator]' is required.]
 
 declare var myArrayLike: {
     0: string;

--- a/baselines/packages/mimir/test/no-duplicate-spread-property/320/test.ts.lint
+++ b/baselines/packages/mimir/test/no-duplicate-spread-property/320/test.ts.lint
@@ -1,0 +1,341 @@
+export {};
+
+declare function get<T>(): T;
+
+declare class WithMethods {
+    foo(): void;
+    bar: () => void;
+    baz: string;
+}
+
+const foo = 'foo';
+
+({
+    x: 1,
+    ~     [error no-duplicate-spread-property: Property 'x' is overridden later.]
+    ...{x: 2, y: 2},
+    ~~~~~~~~~~~~~~~  [error no-duplicate-spread-property: All properties of this object are overridden later.]
+    y: 1,
+    ...{x: 3},
+});
+
+({
+    foo,
+    ~~~  [error no-duplicate-spread-property: Property 'foo' is overridden later.]
+    ...{foo},
+});
+
+({
+    [foo]: 1,
+    ~~~~~     [error no-duplicate-spread-property: Property '[foo]' is overridden later.]
+    ...{[foo]: 2},
+});
+
+({
+    '__@iterator': 1,
+    [Symbol.iterator]: 1,
+    ~~~~~~~~~~~~~~~~~     [error no-duplicate-spread-property: Property '[Symbol.iterator]' is overridden later.]
+    ...{[Symbol.iterator]: 2},
+});
+
+({
+    [get<string>()]: 1,
+    ...{[get<string>()]: 2},
+});
+
+({
+    [get<'foo'>()]: 1,
+    ~~~~~~~~~~~~~~     [error no-duplicate-spread-property: Property '[get<'foo'>()]' is overridden later.]
+    ...{[get<'foo'>()]: 2},
+    ~~~~~~~~~~~~~~~~~~~~~~  [error no-duplicate-spread-property: All properties of this object are overridden later.]
+    ...{[foo]: 3},
+});
+
+({
+    foo: 1,
+    bar: 1,
+    ~~~     [error no-duplicate-spread-property: Property 'bar' is overridden later.]
+    baz: 1,
+    ~~~     [error no-duplicate-spread-property: Property 'baz' is overridden later.]
+    ...get<{foo?: string, bar: number, baz: boolean | undefined}>(),
+});
+
+({
+    foo: 1,
+    bar: 1,
+    ~~~     [error no-duplicate-spread-property: Property 'bar' is overridden later.]
+    baz: 1,
+    bas: 1,
+    ...get<{foo: string, bar: number, bas: number} | {bar: number, baz: boolean, bas?: number}>(),
+    ...Boolean() && {foo},
+});
+
+{
+    let a, b;
+    ({[foo]: a, foo: b, ...{}} = get<{foo: string}>());
+}
+
+({
+    foo: 1,
+    bar: 1,
+    ~~~     [error no-duplicate-spread-property: Property 'bar' is overridden later.]
+    baz: 1,
+    ~~~     [error no-duplicate-spread-property: Property 'baz' is overridden later.]
+    ...get<WithMethods>(),
+});
+
+({
+    foo() {},
+    bar: () => {},
+    ~~~            [error no-duplicate-spread-property: Property 'bar' is overridden later.]
+    baz: get<() => void>(),
+    ~~~                     [error no-duplicate-spread-property: Property 'baz' is overridden later.]
+    ...get<WithMethods>(),
+});
+
+({
+    foo() {},
+    ~~~       [error no-duplicate-spread-property: Property 'foo' is overridden later.]
+    bar: () => {},
+    ~~~            [error no-duplicate-spread-property: Property 'bar' is overridden later.]
+    baz: get<() => void>(),
+    ~~~                     [error no-duplicate-spread-property: Property 'baz' is overridden later.]
+    ...get<{foo(): void, bar: () => void, baz: number}>(),
+});
+
+({
+    ...get<WithMethods>(),
+    ~~~~~~~~~~~~~~~~~~~~~  [error no-duplicate-spread-property: All properties of this object are overridden later.]
+    foo() {},
+    bar: () => {},
+    baz: get<() => void>(),
+});
+
+({
+    ...get<{foo: number, bar: number, baz: number}>(),
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  [error no-duplicate-spread-property: All properties of this object are overridden later.]
+    foo() {},
+    bar: () => {},
+    baz: get<() => void>(),
+});
+
+({
+    prop: 1,
+    ...get<unknown>(),
+    prop2: 2,
+    ...get<any>(),
+});
+
+var v: any;
+({v, ...{v}} = get<Record<string, any>>());
+
+({
+    ['foo'+Math.random()]: 1,
+    ['foo'+Math.random()]: 1,
+    ['bar'+Math.random()]: 1,
+    ['bar'+Math.random()]: 1,
+    ...{
+        ['foo'+Math.random()]: 2,
+        ['bar'+Math.random()]: 2,
+        bar: 2,
+    },
+    ...{
+        ['foo'+Math.random()]: 2.5,
+        ['bar'+Math.random()]: 2.5,
+    },
+    bar: 3,
+    ['foo'+Math.random()]: 3,
+    ['bar'+Math.random()]: 3,
+});
+
+({
+    [get<'foo' | 'bar'>()]: 1,
+    ...{
+        foo: 2,
+    },
+});
+
+({
+    ...{
+        foo: 2,
+        bar: 2,
+    },
+    [get<'foo' | 'bar'>()]: 1,
+});
+
+({
+    ...{
+        foo: 2,
+    },
+    [get<'foo' | 'bar'>()]: 1,
+});
+
+({
+    [get<'foo' | 'bar'>()]: 1,
+    ...{
+        foo: 2,
+    },
+    [get<'foo' | 'bar'>()]: 3,
+});
+
+({
+    [get<'foo' | 'bar'>()]: 1,
+    ~~~~~~~~~~~~~~~~~~~~~~     [error no-duplicate-spread-property: Property '[get<'foo' | 'bar'>()]' is overridden later.]
+    ...{
+        foo: 2,
+        bar: 2,
+    },
+});
+
+({
+    [get<'foo' | 'bar' | number>()]: 1,
+    ...{
+        foo: 2,
+        bar: 2,
+    },
+});
+
+({
+    foo: 1,
+    ...new class {
+        get foo() { return 1; }
+        set foo(v) {}
+        bar = 1;
+    },
+});
+
+({
+    foo: 1,
+    ~~~     [error no-duplicate-spread-property: Property 'foo' is overridden later.]
+    ...{
+        get foo() { return 1; },
+        bar: 2,
+    },
+});
+
+({
+    foo: 1,
+    ~~~     [error no-duplicate-spread-property: Property 'foo' is overridden later.]
+    ...{
+        get foo() { return 1; },
+        set foo(v: number) {},
+        bar: 2,
+    },
+});
+
+({
+    foo: 1,
+    ~~~     [error no-duplicate-spread-property: Property 'foo' is overridden later.]
+    ...{
+        set foo(v: number) {},
+        bar: 2,
+    },
+});
+
+({
+    get foo() { return 1; },
+    set foo(v: number) {},
+    ...{
+        bar: 1,
+    },
+});
+
+({
+    get foo() { return 1; },
+        ~~~                  [error no-duplicate-spread-property: Property 'foo' is overridden later.]
+    set foo(v: number) {},
+        ~~~                [error no-duplicate-spread-property: Property 'foo' is overridden later.]
+    ...{
+        foo: 2,
+    },
+});
+
+({
+    ...{
+    ~~~~
+        get foo() { return 1 },
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    },
+~~~~~  [error no-duplicate-spread-property: All properties of this object are overridden later.]
+    get foo() { return 2; },
+    set foo(v: number) {},
+});
+
+({
+    foo: 1,
+    ~~~     [error no-duplicate-spread-property: Property 'foo' is overridden later.]
+    bar: 1,
+    ~~~     [error no-duplicate-spread-property: Property 'bar' is overridden later.]
+    ...get<{bar: number} & Record<'foo' | 'baz', number>>(),
+    bas: 1,
+});
+
+({
+    ...get<{bar: number} & Record<'foo' | 'baz', number>>(),
+    foo: 1,
+    bar: 1,
+    bas: 1,
+});
+
+({
+    ...get<{bar: number} & Record<'foo' | 'baz', number>>(),
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  [error no-duplicate-spread-property: All properties of this object are overridden later.]
+    foo: 1,
+    bar: 1,
+    baz: 1,
+});
+
+({
+    bar: 1,
+    ~~~     [error no-duplicate-spread-property: Property 'bar' is overridden later.]
+    ...get<{bar: number} & Record<string, number>>(),
+});
+
+({
+    ...get<{bar: number} & Record<string, number>>(),
+    bar: 1,
+});
+
+function test<T, U extends T, V extends any, W extends object>(t: T, u: U, v: V, w: W) {
+    ({foo: 1, ...t, ...u, ...v});
+    ({valueOf: null, toString: null, ...w}); // make sure we don't use the apparent type
+}
+
+function test2<T extends Record<'foo', number>, U extends T, V extends T & Record<'bar', number>>(t: T, u: U, v: V) {
+    ({foo: 1, bar: 1, ...t});
+      ~~~                     [error no-duplicate-spread-property: Property 'foo' is overridden later.]
+    ({foo: 1, bar: 1, ...u});
+      ~~~                     [error no-duplicate-spread-property: Property 'foo' is overridden later.]
+    ({...t, ...u});
+    ({...t, ...get<T>()});
+    ({...u, ...t});
+    ({...t, ...u, foo: 1});
+    ({foo: 1, bar: 1, ...get<T & {bar: number}>()});
+      ~~~                                            [error no-duplicate-spread-property: Property 'foo' is overridden later.]
+              ~~~                                    [error no-duplicate-spread-property: Property 'bar' is overridden later.]
+    ({foo: 1, bar: 1, ...v});
+      ~~~                     [error no-duplicate-spread-property: Property 'foo' is overridden later.]
+              ~~~             [error no-duplicate-spread-property: Property 'bar' is overridden later.]
+}
+
+function test3<T>(t: T) {
+    ({foo: 1, bar: 1, ...get<T extends number ? {foo: 1} : {bar: 1}>()});
+    ({foo: 1, bar: 1, ...get<T extends number ? {foo: 1} : {foo: 2}>()});
+      ~~~                                                                 [error no-duplicate-spread-property: Property 'foo' is overridden later.]
+}
+
+function test4<T extends {foo: 1} | {bar: 1}, U extends {foo: 1} | {foo: 2}>(t: T, u: U) {
+    ({foo: 1, bar: 1, ...t});
+    ({foo: 1, bar: 1, ...u});
+      ~~~                     [error no-duplicate-spread-property: Property 'foo' is overridden later.]
+}
+
+const symbol = Symbol();
+({
+    ...{[symbol]: 1},
+    [symbol]: 1
+});
+({
+    [symbol]: 1
+    ...{[symbol]: 1},
+});

--- a/baselines/packages/mimir/test/no-duplicate-spread-property/default/test.ts.lint
+++ b/baselines/packages/mimir/test/no-duplicate-spread-property/default/test.ts.lint
@@ -329,3 +329,15 @@ function test4<T extends {foo: 1} | {bar: 1}, U extends {foo: 1} | {foo: 2}>(t: 
     ({foo: 1, bar: 1, ...u});
       ~~~                     [error no-duplicate-spread-property: Property 'foo' is overridden later.]
 }
+
+const symbol = Symbol();
+({
+    ...{[symbol]: 1},
+    ~~~~~~~~~~~~~~~~  [error no-duplicate-spread-property: All properties of this object are overridden later.]
+    [symbol]: 1
+});
+({
+    [symbol]: 1
+    ~~~~~~~~    [error no-duplicate-spread-property: Property '[symbol]' is overridden later.]
+    ...{[symbol]: 1},
+});

--- a/baselines/packages/mimir/test/no-duplicate-spread-property/loose/test.ts.lint
+++ b/baselines/packages/mimir/test/no-duplicate-spread-property/loose/test.ts.lint
@@ -289,3 +289,13 @@ function test4<T extends {foo: 1} | {bar: 1}, U extends {foo: 1} | {foo: 2}>(t: 
     ({foo: 1, bar: 1, ...t});
     ({foo: 1, bar: 1, ...u});
 }
+
+const symbol = Symbol();
+({
+    ...{[symbol]: 1},
+    [symbol]: 1
+});
+({
+    [symbol]: 1
+    ...{[symbol]: 1},
+});

--- a/baselines/packages/mimir/test/no-unstable-api-use/default/test.ts.lint
+++ b/baselines/packages/mimir/test/no-unstable-api-use/default/test.ts.lint
@@ -472,14 +472,14 @@ declare var myIterable: {
 }
 
 myIterable[Symbol.iterator];
-~~~~~~~~~~~~~~~~~~~~~~~~~~~  [error no-unstable-api-use: Method 'Symbol.iterator' is deprecated: use async iterator instead.]
+~~~~~~~~~~~~~~~~~~~~~~~~~~~  [error no-unstable-api-use: Method '[Symbol.iterator]' is deprecated: use async iterator instead.]
 myIterable['__@iterator'];
 myIterable[Symbol.asyncIterator];
 myIterable['__@asyncIterator'];
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  [error no-unstable-api-use: Method '__@asyncIterator' is deprecated.]
 
 const {[Symbol.iterator]: iteratorFn, [Symbol.asyncIterator]: asyncIteratorFn} = myIterable;
-       ~~~~~~~~~~~~~~~~~                                                                     [error no-unstable-api-use: Method 'Symbol.iterator' is deprecated: use async iterator instead.]
+       ~~~~~~~~~~~~~~~~~                                                                     [error no-unstable-api-use: Method '[Symbol.iterator]' is deprecated: use async iterator instead.]
 
 /**@deprecated var*/
 declare var myDeprecatedCallable: {

--- a/baselines/packages/mimir/test/no-useless-assertion/loose/type-assertion.ts.fix
+++ b/baselines/packages/mimir/test/no-useless-assertion/loose/type-assertion.ts.fix
@@ -38,6 +38,8 @@ e as typeof e;
 ['a', 'b', 'c'].map((element, i) => [i, element] as [number, string]);
 let f: Array<[number, string]> = ['a', 'b', 'c'].map((element, i) => [i, element] as [number, string]);
 
+[] as [];
+
 declare const g: '1.0';
 g as string === '2.0';
 declare let h: Array<'a' | 'b' | 'c'>;

--- a/baselines/packages/mimir/test/no-useless-assertion/loose/type-assertion.ts.lint
+++ b/baselines/packages/mimir/test/no-useless-assertion/loose/type-assertion.ts.lint
@@ -55,6 +55,8 @@ e as typeof e;
 ['a', 'b', 'c'].map((element, i) => [i, element] as [number, string]);
 let f: Array<[number, string]> = ['a', 'b', 'c'].map((element, i) => [i, element] as [number, string]);
 
+[] as [];
+
 declare const g: '1.0';
 g as string === '2.0';
 declare let h: Array<'a' | 'b' | 'c'>;

--- a/baselines/packages/mimir/test/no-useless-assertion/strict/type-assertion.ts.fix
+++ b/baselines/packages/mimir/test/no-useless-assertion/strict/type-assertion.ts.fix
@@ -38,6 +38,8 @@ e as typeof e;
 ['a', 'b', 'c'].map((element, i) => [i, element] as [number, string]);
 let f: Array<[number, string]> = ['a', 'b', 'c'].map((element, i) => [i, element] as [number, string]);
 
+[] as [];
+
 declare const g: '1.0';
 g as string === '2.0';
 declare let h: Array<'a' | 'b' | 'c'>;

--- a/baselines/packages/mimir/test/no-useless-assertion/strict/type-assertion.ts.lint
+++ b/baselines/packages/mimir/test/no-useless-assertion/strict/type-assertion.ts.lint
@@ -53,6 +53,8 @@ e as typeof e;
 ['a', 'b', 'c'].map((element, i) => [i, element] as [number, string]);
 let f: Array<[number, string]> = ['a', 'b', 'c'].map((element, i) => [i, element] as [number, string]);
 
+[] as [];
+
 declare const g: '1.0';
 g as string === '2.0';
 declare let h: Array<'a' | 'b' | 'c'>;

--- a/packages/mimir/package.json
+++ b/packages/mimir/package.json
@@ -30,7 +30,7 @@
     "chalk": "^2.3.2",
     "debug": "^4.0.0",
     "tslib": "^1.8.1",
-    "tsutils": "^3.8.0"
+    "tsutils": "^3.11.0"
   },
   "peerDependencies": {
     "typescript": ">= 3.1.1 || >= 3.4.0-dev || >= 3.5.0-dev"

--- a/packages/mimir/src/rules/no-duplicate-spread-property.ts
+++ b/packages/mimir/src/rules/no-duplicate-spread-property.ts
@@ -1,7 +1,14 @@
 import { TypedRule, excludeDeclarationFiles, requiresCompilerOption } from '@fimbul/ymir';
 import * as ts from 'typescript';
-import { isReassignmentTarget, isObjectType, isClassLikeDeclaration, getPropertyName, isIntersectionType, isUnionType } from 'tsutils';
-import { lateBoundPropertyNames } from '../utils';
+import {
+    isReassignmentTarget,
+    isObjectType,
+    isClassLikeDeclaration,
+    getPropertyName,
+    isIntersectionType,
+    isUnionType,
+    getLateBoundPropertyNames,
+} from 'tsutils';
 
 interface PropertyInfo {
     known: boolean;
@@ -73,10 +80,10 @@ export class Rule extends TypedRule {
                         assignedNames: [escapedName],
                     };
                 }
-                const lateBound = lateBoundPropertyNames((<ts.ComputedPropertyName>property.name).expression, this.checker);
+                const lateBound = getLateBoundPropertyNames((<ts.ComputedPropertyName>property.name).expression, this.checker);
                 if (!lateBound.known)
                     return emptyPropertyInfo;
-                const names = lateBound.properties.map((p) => p.symbolName);
+                const names = lateBound.names.map((p) => p.symbolName);
                 return {
                     names,
                     known: true,

--- a/packages/mimir/src/rules/no-restricted-property-access.ts
+++ b/packages/mimir/src/rules/no-restricted-property-access.ts
@@ -1,6 +1,6 @@
 import { excludeDeclarationFiles, TypedRule } from '@fimbul/ymir';
 import * as ts from 'typescript';
-import { lateBoundPropertyNames, propertiesOfType } from '../utils';
+import { propertiesOfType } from '../utils';
 import {
     isThisParameter,
     isTypeParameter,
@@ -9,6 +9,7 @@ import {
     isFunctionScopeBoundary,
     isMethodDeclaration,
     hasModifier,
+    getLateBoundPropertyNames,
  } from 'tsutils';
 
 @excludeDeclarationFiles
@@ -20,11 +21,11 @@ export class Rule extends TypedRule {
     }
 
     private checkElementAccess(node: ts.ElementAccessExpression) {
-        const {properties} = lateBoundPropertyNames(node.argumentExpression, this.checker);
-        if (properties.length === 0)
+        const {names} = getLateBoundPropertyNames(node.argumentExpression, this.checker);
+        if (names.length === 0)
             return;
         const type = this.checker.getApparentType(this.checker.getTypeAtLocation(node.expression));
-        for (const {symbol, name} of propertiesOfType(type, properties))
+        for (const {symbol, name} of propertiesOfType(type, names))
             this.checkSymbol(symbol, name, node, node.expression, type);
     }
 

--- a/packages/mimir/src/rules/no-unstable-api-use.ts
+++ b/packages/mimir/src/rules/no-unstable-api-use.ts
@@ -10,9 +10,10 @@ import {
     isPropertyAssignment,
     isReassignmentTarget,
     isShorthandPropertyAssignment,
+    getLateBoundPropertyNames,
 } from 'tsutils';
 import * as ts from 'typescript';
-import { elementAccessSymbols, propertiesOfType, lateBoundPropertyNames } from '../utils';
+import { elementAccessSymbols, propertiesOfType } from '../utils';
 
 const functionLikeSymbol = ts.SymbolFlags.Function | ts.SymbolFlags.Method;
 const signatureFormatFlags = ts.TypeFormatFlags.UseFullyQualifiedType | ts.TypeFormatFlags.UseAliasDefinedOutsideCurrentScope;
@@ -74,7 +75,7 @@ export class Rule extends TypedRule {
                 } else {
                     for (const {symbol, name} of propertiesOfType(
                             type,
-                            lateBoundPropertyNames((<ts.ComputedPropertyName>element.propertyName).expression!, this.checker).properties,
+                            getLateBoundPropertyNames((<ts.ComputedPropertyName>element.propertyName).expression!, this.checker).names,
                         )
                     )
                         this.checkStability(symbol, element.propertyName, name, describeWithName);

--- a/packages/mimir/src/rules/no-useless-try-catch.ts
+++ b/packages/mimir/src/rules/no-useless-try-catch.ts
@@ -4,9 +4,10 @@ import {
     isIdentifier,
     isInSingleStatementContext,
     isBlockScopedDeclarationStatement,
+    unwrapParentheses,
 } from 'tsutils';
 import * as ts from 'typescript';
-import { unwrapParens, tryStatements } from '../utils';
+import { tryStatements } from '../utils';
 
 @excludeDeclarationFiles
 export class Rule extends AbstractRule {
@@ -94,6 +95,6 @@ function isRethrow(node: ts.CatchClause): boolean {
 function throwsVariable(statement: ts.Statement, name: ts.Identifier): boolean {
     if (!isThrowStatement(statement) || statement.expression === undefined)
         return false;
-    const expression = unwrapParens(statement.expression);
+    const expression = unwrapParentheses(statement.expression);
     return isIdentifier(expression) && expression.escapedText === name.escapedText;
 }

--- a/packages/mimir/test/no-duplicate-spread-property/320.test.json
+++ b/packages/mimir/test/no-duplicate-spread-property/320.test.json
@@ -1,5 +1,5 @@
 {
   "project": "tsconfig.json",
   "files": "*.ts",
-  "typescriptVersion": ">=3.3.0"
+  "typescriptVersion": "~3.2.0"
 }

--- a/packages/mimir/test/no-duplicate-spread-property/test.ts
+++ b/packages/mimir/test/no-duplicate-spread-property/test.ts
@@ -289,3 +289,13 @@ function test4<T extends {foo: 1} | {bar: 1}, U extends {foo: 1} | {foo: 2}>(t: 
     ({foo: 1, bar: 1, ...t});
     ({foo: 1, bar: 1, ...u});
 }
+
+const symbol = Symbol();
+({
+    ...{[symbol]: 1},
+    [symbol]: 1
+});
+({
+    [symbol]: 1
+    ...{[symbol]: 1},
+});

--- a/packages/mimir/test/no-useless-assertion/type-assertion.ts
+++ b/packages/mimir/test/no-useless-assertion/type-assertion.ts
@@ -38,6 +38,8 @@ e as typeof e;
 ['a', 'b', 'c'].map((element, i) => [i, element] as [number, string]);
 let f: Array<[number, string]> = ['a', 'b', 'c'].map((element, i) => [i, element] as [number, string]);
 
+[] as [];
+
 declare const g: '1.0';
 g as string === '2.0';
 declare let h: Array<'a' | 'b' | 'c'>;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4644,7 +4644,14 @@ tsutils@^2.29.0:
   dependencies:
     tslib "^1.8.1"
 
-tsutils@^3.5.0, tsutils@^3.5.1, tsutils@^3.6.0, tsutils@^3.8.0:
+tsutils@^3.11.0:
+  version "3.11.0"
+  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-3.11.0.tgz#a180bb9f110608810ddb513067e59cd4e4c23474"
+  integrity sha512-RRtGX1FVfHm1+P9XVqN+RxqUa8ZCZ2LjaPyaRUQH7Wvn9cYAkpz/cZKy+BWU/+fncFqjW/+PVgRWF4Ky5IGbjQ==
+  dependencies:
+    tslib "^1.8.1"
+
+tsutils@^3.5.0, tsutils@^3.5.1, tsutils@^3.6.0:
   version "3.10.0"
   resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-3.10.0.tgz#6f1c95c94606e098592b0dff06590cf9659227d6"
   integrity sha512-q20XSMq7jutbGB8luhKKsQldRKWvyBO2BGqni3p4yq8Ys9bEP/xQw3KepKmMRt9gJ4lvQSScrihJrcKdKoSU7Q==


### PR DESCRIPTION
#### Checklist

- [x] Part of: #618 (late bound symbol properties)
- [x] Added or updated tests / baselines

#### Overview of change 
Moves some utility functions to tsutils.
Results in better checking of late bound symbol property names and better display names for computed properties.