### PR TITLE
refactor release process

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,4 +20,4 @@ deploy:
     skip_cleanup: true
     script: bash -c 'set -o pipefail && echo $NPM_AUTH > ~/.npmrc && npm whoami | xargs echo logged in as && node scripts/release && node scripts/github-release'
     on:
-      condition: "$TRAVIS_EVENT_TYPE != cron && $TRAVIS_COMMIT_MESSAGE =~ ^v[0-9]+[.][0-9]+[.][0-9]+$"
+      condition: "$TRAVIS_EVENT_TYPE != cron && $TRAVIS_COMMIT_MESSAGE =~ ^v[0-9]+[.][0-9]+[.][0-9]+"

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,5 +19,6 @@ deploy:
   - provider: script
     skip_cleanup: true
     script: bash -c 'set -o pipefail && echo $NPM_AUTH > ~/.npmrc && npm whoami | xargs echo logged in as && node scripts/release && node scripts/github-release'
+    all_branches: true
     on:
       condition: "$TRAVIS_EVENT_TYPE != cron && $TRAVIS_COMMIT_MESSAGE =~ ^v[0-9]+[.][0-9]+[.][0-9]+"

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
-  "version": "0.22.0",
+  "version": "0.21.0",
+  "nextVersion": "0.22.0",
   "private": true,
   "scripts": {
     "clean": "rimraf \"{packages/*/{index,{src,language-service}/**/*,test/*.spec},scripts/!(last-travis-nightly)}.{js?(.map),d.ts}\" \"*.tsbuildinfo\"",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "codecov": "^3.0.0",
     "dependency-cruiser": "^4.0.0",
     "diff": "^4.0.1",
+    "escape-string-regexp": "^2.0.0",
     "github-url-to-object": "^4.0.4",
     "glob": "^7.1.2",
     "mkdirp": "^0.5.1",

--- a/packages/wotan/package.json
+++ b/packages/wotan/package.json
@@ -30,7 +30,6 @@
   "homepage": "https://github.com/fimbullinter/wotan#readme",
   "devDependencies": {
     "@types/debug": "^4.0.0",
-    "@types/escape-string-regexp": "^1.0.0",
     "@types/is-negated-glob": "^1.0.0",
     "@types/js-yaml": "^3.10.1",
     "@types/json5": "0.0.30",

--- a/scripts/cleanup-tests.ts
+++ b/scripts/cleanup-tests.ts
@@ -3,8 +3,9 @@ import * as semver from 'semver';
 import * as path from 'path';
 import * as fs from 'fs';
 import * as rimraf from 'rimraf';
+import { getRootPackage } from './util';
 
-const minimumTypescriptVersion = new semver.Range(require('../package.json').peerDependencies.typescript).set[0][0].semver;
+const minimumTypescriptVersion = new semver.Range(getRootPackage().peerDependencies.typescript).set[0][0].semver;
 const supportedRange = new semver.Range('>=' + minimumTypescriptVersion.version);
 
 for (const file of glob.sync('packages/*/test/**/{,*.}test.json')) {

--- a/scripts/github-release.ts
+++ b/scripts/github-release.ts
@@ -1,20 +1,30 @@
 import * as fs from 'fs';
 import * as parseGithubUrl from 'github-url-to-object';
-import * as Github  from '@octokit/rest';
+import * as Github from '@octokit/rest';
+import { getLastReleaseTag, getRootPackage } from './util';
 
 if (!process.env.GITHUB_TOKEN) {
     console.error('Missing environment variable GITHUB_TOKEN');
     throw process.exit(1);
 }
 
+const [tag, newerCommits] = getLastReleaseTag();
+if (newerCommits !== 0) {
+    console.error('Missing release tag on the current commit.');
+    throw process.exit(1);
+}
 const content = fs.readFileSync('./CHANGELOG.md', 'utf8');
-const re = /^## (v\d+\.\d+\.\d+)$/mg;
+const re = /^## (v\d+\.\d+\.\d+(?:-\w+\.\d+)?)$/mg;
 const startMatch = re.exec(content)!;
-const start = startMatch.index + startMatch[0].length;
-const end = re.exec(content)!.index;
-const body = content.substring(start, end).trim();
-const tag = startMatch[1];
-const { user, repo } = parseGithubUrl(require(process.cwd() + '/package.json').repository)!;
+let body: string | undefined;
+if (startMatch[1] !== tag) {
+    console.log('No CHANGELOG entry for %s', tag);
+} else {
+    const start = startMatch.index + startMatch[0].length;
+    const end = re.exec(content)!.index;
+    body = content.substring(start, end).trim();
+}
+const { user, repo } = parseGithubUrl(getRootPackage().repository)!;
 
 const ghClient = new Github();
 ghClient.authenticate({

--- a/scripts/nightly.ts
+++ b/scripts/nightly.ts
@@ -20,7 +20,7 @@ const {packages, publicPackages} = getPackages();
 ensureCleanTree(Array.from(publicPackages.keys(), (p) => 'packages/' + p));
 
 const currentDate = new Date();
-const version = // tslint:disable-next-line
+const version =
     `${getRootPackage().nextVersion}-dev.${currentDate.getFullYear() * 10000 + (currentDate.getMonth() + 1) * 100 + currentDate.getDate()}`;
 
 const needsRelease = new Set<string>();
@@ -55,7 +55,7 @@ function updatePublicPackageDependencies() {
 }
 
 const lastNightly = process.argv[2]; // revision of the last nightly
-const lastReleaseTag = getLastReleaseTag();
+const [lastReleaseTag] = getLastReleaseTag();
 console.log('last stable release tag', lastReleaseTag);
 // if there was a release since the last nightly, only get the diff since that release
 const diffStart = lastNightly && cp.execSync(`git rev-list ${lastReleaseTag}...${lastNightly}`, {encoding: 'utf8'}).split(/\r?\n/)[0]

--- a/scripts/nightly.ts
+++ b/scripts/nightly.ts
@@ -7,6 +7,7 @@ import {
     execAndLog,
     ensureCleanTree,
     sortPackagesForPublishing,
+    getRootPackage,
 } from './util';
 
 if (process.argv.length < 3) {
@@ -20,7 +21,7 @@ ensureCleanTree(Array.from(publicPackages.keys(), (p) => 'packages/' + p));
 
 const currentDate = new Date();
 const version = // tslint:disable-next-line
-    `${require('../package.json').version}-dev.${currentDate.getFullYear() * 10000 + (currentDate.getMonth() + 1) * 100 + currentDate.getDate()}`;
+    `${getRootPackage().nextVersion}-dev.${currentDate.getFullYear() * 10000 + (currentDate.getMonth() + 1) * 100 + currentDate.getDate()}`;
 
 const needsRelease = new Set<string>();
 function markForRelease(name: string) {

--- a/scripts/prepare-release.ts
+++ b/scripts/prepare-release.ts
@@ -37,7 +37,7 @@ const changedPackages =
     releaseVersion.patch === 0 &&
     (releaseVersion.prerelease.length === 0 || +releaseVersion.prerelease[1] === 0)
         ? new Set(packages.keys())
-        : getChangedPackageNames(getLastReleaseTag(), packages.keys());
+        : getChangedPackageNames(getLastReleaseTag()[0], packages.keys());
 const needsRelease = new Set<string>();
 
 function determineReleaseTypeAndVersion([type, tag]: string[], currentVersion: string, nextVersion: string) {

--- a/scripts/prepare-release.ts
+++ b/scripts/prepare-release.ts
@@ -20,7 +20,7 @@ const {releaseType, releaseVersion, releaseTag} =
 
 if (releaseType !== 'prerelease' || releaseTag === 'rc') {
     if (!getChangeLogForVersion(releaseVersion.version))
-        throw new Error(`No CHANGELOG entry for 'v${releaseVersion.version}'.`)
+        throw new Error(`No CHANGELOG entry for 'v${releaseVersion.version}'.`);
     if (releaseType === 'patch') {
         // branch name must either be 'master' or 'release-<major>.<minor>'
         ensureBranchMatches(new RegExp(`^(?:master|release-${rootManifest.version.replace(/^(\d+\.\d+)\..+$/, '$1')})$`));

--- a/scripts/prepare-release.ts
+++ b/scripts/prepare-release.ts
@@ -8,56 +8,96 @@ import {
     ensureBranch,
     ensureCleanTree,
     Dependencies,
+    ensureBranchMatches,
+    getRootPackage,
 } from './util';
-import * as semver from 'semver';
+import { SemVer, Range, satisfies } from 'semver';
 
-ensureBranch('master');
+const rootManifest = getRootPackage();
+const {releaseType, releaseVersion, releaseTag} =
+    determineReleaseTypeAndVersion(process.argv.slice(2), rootManifest.version, rootManifest.nextVersion);
+
+if (releaseType === 'patch') {
+    // branch name must either be 'master' or 'release-<major>.<minor>'
+    ensureBranchMatches(new RegExp(`^(?:master|release-${rootManifest.version.replace(/^(\d+\.\d+)\..+$/, '$1')})$`));
+} else if (releaseType !== 'prerelease' || releaseTag === 'rc') {
+    ensureBranch('master');
+}
 ensureCleanTree(undefined, ['CHANGELOG.md']);
 
 execAndLog('yarn');
 execAndLog('yarn verify');
 ensureCleanTree(undefined, ['CHANGELOG.md', 'yarn.lock']);
 
-const rootManifest = require('../package.json');
-const releaseVersion = rootManifest.version;
-const version = new semver.SemVer(releaseVersion);
-const isMajor = version.minor === 0 && version.patch === 0 && version.prerelease.length === 0 && version.build.length === 0;
-
 const {packages} = getPackages();
 
-const changedPackages = isMajor ? new Set<string>(packages.keys()) : getChangedPackageNames(getLastReleaseTag(), packages.keys());
+// if the current release is a major release OR the first prerelease of a tag of a major version, release all packages
+const changedPackages =
+    releaseVersion.minor === 0 &&
+    releaseVersion.patch === 0 &&
+    (releaseVersion.prerelease.length === 0 || +releaseVersion.prerelease[1] === 0)
+        ? new Set(packages.keys())
+        : getChangedPackageNames(getLastReleaseTag(), packages.keys());
 const needsRelease = new Set<string>();
+
+function determineReleaseTypeAndVersion([type, tag]: string[], currentVersion: string, nextVersion: string) {
+    if (type === undefined)
+        return <const>{releaseType: /^\d+\.0\.0$/.test(nextVersion) ? 'major' : 'minor', releaseVersion: new SemVer(nextVersion)};
+    switch (type) {
+        case 'patch':
+            return <const>{releaseType: 'patch', releaseVersion: new SemVer(currentVersion).inc('patch')};
+        case 'prerelease': {
+            if (tag === undefined)
+                throw new Error("Release type 'prerelease' requires a tag name, but none was specified.");
+            const curr = new SemVer(currentVersion);
+            const next = new SemVer(nextVersion);
+            const release = curr.compareMain(next) === 0 ? curr : next;
+            // if we the current version is already a prerelease, we need to increment that one
+            if (release.prerelease[0] !== tag) {
+                release.prerelease = [tag, '0'];
+            } else {
+                release.prerelease = [tag, String(+curr.prerelease[1] + 1)];
+            }
+
+            return <const>{releaseType: 'prerelease', releaseVersion: new SemVer(release.format()), releaseTag: tag};
+        }
+        default:
+            throw new Error(
+                `Unexpected release type '${
+                    type
+                }'. Only 'patch' and 'prerelease' are allowed. 'major' and 'minor' are determined automatically.`,
+            );
+    }
+}
 
 function markForRelease(name: string) {
     if (needsRelease.has(name))
-        return;
+        return false;
     needsRelease.add(name);
-    updateManifest(rootManifest);
-    for (const [localName, manifest] of packages)
-        if (updateManifest(manifest))
-            markForRelease(localName);
+    return true;
 }
 
-function updateManifest(manifest: PackageData): boolean {
+function updateManifest(manifest: PackageData, willBeReleased: boolean): boolean {
     let updated = false;
-    for (const localName of packages.keys()) {
-        const changed = changedPackages.has(localName);
-        if (!changed && !needsRelease.has(localName))
-            continue;
+    for (const localName of needsRelease.keys()) {
         const {name} = packages.get(localName)!;
-        update(manifest.dependencies, name, changed);
-        update(manifest.peerDependencies, name, changed);
+        update(manifest.dependencies, name);
+        update(manifest.peerDependencies, name);
     }
     return updated;
 
-    function update(dependencies: Dependencies | undefined, name: string, changed: boolean) {
+    function update(dependencies: Dependencies | undefined, name: string) {
         if (!dependencies || !dependencies[name])
             return;
-        const range = new semver.Range(dependencies[name]);
-        // make sure to publish a new version of a dependent package if the updated dependency wouldn't satisfy the constraint
-        if (changed || !semver.satisfies(version, range)) {
-            dependencies[name] = `^${releaseVersion}`;
-            updated = true;
+        const range = new Range(dependencies[name]);
+        // if we are publishing the package anyway, update the constraint to the current released version to ensure compatibility
+        if (willBeReleased || !satisfies(releaseVersion, range)) {
+            // preserve the range sigil, if present
+            const newRange = `${range.raw.replace(/\d.+$/, '')}${releaseVersion.version}`;
+            if (newRange !== range.raw) {
+                dependencies[name] = newRange;
+                updated = true;
+            }
         }
     }
 }
@@ -65,13 +105,24 @@ function updateManifest(manifest: PackageData): boolean {
 for (const name of changedPackages)
     markForRelease(name);
 
+let dependencyUpdated;
+do {
+    dependencyUpdated = false;
+    for (const [localName, manifest] of packages)
+        if (updateManifest(manifest, needsRelease.has(localName)) && markForRelease(localName))
+            dependencyUpdated = true;
+} while (dependencyUpdated);
+
 const supportedTypescriptVersions = rootManifest.peerDependencies.typescript;
-rootManifest.version = semver.inc(version, 'minor');
+rootManifest.version = releaseVersion.version;
+if (releaseType === 'major' || releaseType === 'minor')
+    rootManifest.nextVersion = new SemVer(releaseVersion.version).inc('minor').version;
+updateManifest(rootManifest, true);
 writeManifest('package.json', rootManifest);
 
 for (const name of needsRelease) {
     const manifest = packages.get(name)!;
-    manifest.version = releaseVersion;
+    manifest.version = releaseVersion.version;
     if (manifest.peerDependencies && manifest.peerDependencies.typescript)
         manifest.peerDependencies.typescript = supportedTypescriptVersions;
     writeManifest(`packages/${name}/package.json`, manifest);
@@ -80,6 +131,6 @@ for (const name of needsRelease) {
 // install dependencies to update yarn.lock
 execAndLog('yarn');
 
-execAndLog(`git commit -a -m "v${releaseVersion}"`);
-execAndLog(`git tag v${releaseVersion}`);
+execAndLog(`git commit -a -m "v${releaseVersion.version}"`);
+execAndLog(`git tag v${releaseVersion.version}`);
 execAndLog(`git push origin master --tags`);

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -4,7 +4,9 @@ import {
     execAndLog,
     ensureCleanTree,
     sortPackagesForPublishing,
+    getRootPackage,
 } from './util';
+import { SemVer } from 'semver';
 
 ensureCleanTree();
 
@@ -12,8 +14,11 @@ const {publicPackages} = getPackages();
 
 const needsRelease = getChangedPackageNames('HEAD^', publicPackages.keys());
 
+const tag = new SemVer(getRootPackage().version).prerelease[0] || 'latest';
+
 for (const name of sortPackagesForPublishing(needsRelease, (p) => publicPackages.get(p)!)) {
     const manifest = publicPackages.get(name)!;
-    execAndLog(`npm publish packages/${name} --tag latest ${process.argv.slice(2).join(' ')}`);
-    execAndLog(`npm dist-tag add ${manifest.name}@${manifest.version} next`);
+    execAndLog(`npm publish packages/${name} --tag ${tag} ${process.argv.slice(2).join(' ')}`);
+    if (tag === 'latest' || tag === 'rc')
+        execAndLog(`npm dist-tag add ${manifest.name}@${manifest.version} next`);
 }

--- a/scripts/updated.ts
+++ b/scripts/updated.ts
@@ -4,7 +4,7 @@ import { getChangedPackageNames, getLastReleaseTag, getPackages } from './util';
 // rev can be any valid git revision
 // if omitted, it defaults to the last release tag
 
-const since = process.argv[2] || getLastReleaseTag();
+const since = process.argv[2] || getLastReleaseTag()[0];
 
 const result = Array.from(getChangedPackageNames(since, getPackages().publicPackages.keys()));
 console.log(result.join(' '));

--- a/scripts/util.ts
+++ b/scripts/util.ts
@@ -13,6 +13,13 @@ export interface PackageData {
     peerDependencies?: Dependencies;
 }
 
+export interface RootPackageData extends PackageData {
+    nextVersion: string;
+    dependencies: Dependencies;
+    devDependencies: Dependencies;
+    peerDependencies: Dependencies;
+}
+
 export function isTreeClean(directories: ReadonlyArray<string> = [], exceptions: ReadonlyArray<string> = []) {
     cp.spawnSync('git', ['update-index', '-q', '--refresh'], {stdio: 'ignore'});
     const modified = cp.spawnSync(
@@ -46,8 +53,18 @@ export function ensureBranch(name: string) {
         throw new Error(`Expected current branch to be ${name}, but it's actually ${branch}.`);
 }
 
+export function ensureBranchMatches(regex: RegExp) {
+    const branch = getCurrentBranch();
+    if (!regex.test(branch))
+    throw new Error(`Expected current branch to match /${regex.source}/${regex.flags}, but it's actually ${branch}.`);
+}
+
 export function getLastReleaseTag() {
     return cp.spawnSync('git', ['describe', '--tags', '--match=v*.*.*', '--abbrev=0'], {encoding: 'utf8'}).stdout.trim();
+}
+
+export function getRootPackage(): RootPackageData {
+    return require('../package.json');
 }
 
 export function getPackages() {

--- a/scripts/util.ts
+++ b/scripts/util.ts
@@ -15,7 +15,7 @@ export interface PackageData {
         type: string;
         url: string;
         directory?: string;
-    }
+    };
 }
 
 export interface RootPackageData extends PackageData {

--- a/scripts/util.ts
+++ b/scripts/util.ts
@@ -1,5 +1,6 @@
 import * as cp from 'child_process';
 import * as fs from 'fs';
+import escapeStringRegexp = require('escape-string-regexp');
 
 export interface Dependencies {
     [name: string]: string;
@@ -159,4 +160,17 @@ export function sortPackagesForPublishing(packageNames: Iterable<string>, getPac
             throw new Error(`Circular dependency: ${Array.from(remaining.values(), ({name}) => name)}`);
     }
     return result;
+}
+
+export function getChangeLogForVersion(version: string) {
+    let content = fs.readFileSync('./CHANGELOG.md', 'utf8');
+    const re = new RegExp(`^## v${escapeStringRegexp(version)}$`, 'm');
+    let match = re.exec(content);
+    if (match === null)
+        return;
+    content = content.slice(match.index + match[0].length);
+    match = /^## (v\d+\.\d+\.\d+(?:-\w+\.\d+)?)$/m.exec(content);
+    if (match !== null)
+        content = content.slice(0, match.index);
+    return content.trim();
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -436,11 +436,6 @@
   resolved "https://registry.yarnpkg.com/@types/diff/-/diff-4.0.2.tgz#2e9bb89f9acc3ab0108f0f3dc4dbdcf2fff8a99c"
   integrity sha512-mIenTfsIe586/yzsyfql69KRnA75S8SVXQbTLpDejRrjH0QSJcpu3AUOi/Vjnt9IOsXKxPhJfGpQUNMueIU1fQ==
 
-"@types/escape-string-regexp@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@types/escape-string-regexp/-/escape-string-regexp-1.0.0.tgz#052d16d87db583b72daceae4eaabddb66954424c"
-  integrity sha512-KAruqgk9/340M4MYYasdBET+lyYN8KMXUuRKWO72f4SbmIMMFp9nnJiXUkJS0HC2SFe4x0R/fLozXIzqoUfSjA==
-
 "@types/events@*":
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@types/events/-/events-3.0.0.tgz#2862f3f58a9a7f7c3e78d79f130dd4d71c25c2a7"


### PR DESCRIPTION
* now allows patch and prereleases
* patch and prereleases (except 'rc') don't need to happen on master
* fixed some weird conditions
* don't publish prereleases as 'latest' and 'next' to npm
* no longer use the most recent changelog for github releases if it doesn't match