### PR TITLE
enhancements for no-restricted-property-access

### DIFF
--- a/baselines/packages/mimir/test/no-restricted-property-access/default/test.ts.lint
+++ b/baselines/packages/mimir/test/no-restricted-property-access/default/test.ts.lint
@@ -1,3 +1,7 @@
+declare function decorator(...args: any[]): any;
+declare const BaseTypeWithoutDeclarations: new () => {};
+declare const BaseTypeWithoutSymbol: new () => object;
+
 class Private {
     private prop = 1;
     other = this['prop'];
@@ -69,9 +73,11 @@ function testProtected(this: Protected) {
               ~~~~~~~~~~~~~~~~~~~~~~~  [error no-restricted-property-access: Property 'prop' is protected and only accessible within class 'Protected' and its subclasses.]
     }
     @decorator(new Protected()['prop'])
-    class Inner {
+    class Inner extends (new Protected()['prop'] ? Object : Object) {
         bar = new Protected()['prop'];
               ~~~~~~~~~~~~~~~~~~~~~~~  [error no-restricted-property-access: Property 'prop' is protected and only accessible within class 'Protected' and its subclasses.]
+        @decorator(new Protected()['prop'])
+        [new Protected()['prop']](@decorator(new Protected()['prop']) param: string) {}
     }
 }
 new Protected()['prop'];
@@ -112,10 +118,63 @@ function testDerivedProtected(this: DerivedProtected) {
     ~~~~~~~~~~~~~~~~~~~~~~~  [error no-restricted-property-access: Property 'prop' is protected and only accessible through an instance of class 'DerivedProtected'.]
 }
 
+interface I { something(): void }
+class DerivedProtectedWithImplements extends Protected implements I {
+    something() {
+        this['prop'];
+        new Protected()['fn'](null!);
+    }
+}
+
 class Unrelated {}
 function testUnrelated(this: Unrelated) {
     new Protected()['prop'];
     ~~~~~~~~~~~~~~~~~~~~~~~  [error no-restricted-property-access: Property 'prop' is protected and only accessible within class 'Protected' and its subclasses.]
+}
+
+class WithoutDeclarations extends BaseTypeWithoutDeclarations {
+    prop = new Protected()['prop'];
+           ~~~~~~~~~~~~~~~~~~~~~~~  [error no-restricted-property-access: Property 'prop' is protected and only accessible within class 'Protected' and its subclasses.]
+}
+
+class WithoutSymbol extends BaseTypeWithoutSymbol {
+    prop = new Protected()['prop'];
+           ~~~~~~~~~~~~~~~~~~~~~~~  [error no-restricted-property-access: Property 'prop' is protected and only accessible within class 'Protected' and its subclasses.]
+}
+
+function mixin<T extends new (...args: any[]) => object>(p: T) {
+    return class extends p {
+        constructor(...args: any[]) {
+            super(...args);
+            new Protected()['prop'];
+            ~~~~~~~~~~~~~~~~~~~~~~~  [error no-restricted-property-access: Property 'prop' is protected and only accessible within class 'Protected' and its subclasses.]
+        }
+    }
+}
+
+function mixin2<T extends new (...args: any[]) => Protected>(p: T) {
+    return class extends p {
+        protected fromMixin = 1;
+        constructor(...args: any[]) {
+            super(...args);
+            this['prop'];
+            new Protected()['prop'];
+            ~~~~~~~~~~~~~~~~~~~~~~~  [error no-restricted-property-access: Property 'prop' is protected and only accessible through an instance of class '(Anonymous class)'.]
+            Protected['fn'](null!);
+        }
+    };
+}
+
+const MixedIn = mixin2(Protected);
+new MixedIn()['fromMixin'];
+~~~~~~~~~~~~~~~~~~~~~~~~~~  [error no-restricted-property-access: Property 'fromMixin' is protected and only accessible within class 'mixin2<typeof Protected>.(Anonymous class) & Protected' and its subclasses.]
+
+class ExtendsMixin extends MixedIn {
+    fn() {
+        this['fromMixin'];
+        new MixedIn()['fromMixin'];
+        ~~~~~~~~~~~~~~~~~~~~~~~~~~  [error no-restricted-property-access: Property 'fromMixin' is protected and only accessible through an instance of class 'ExtendsMixin'.]
+    }
 }
 
 new class {
@@ -154,7 +213,6 @@ abstract class Abstract {
     abstract getProp(): number;
     other = this['prop'] + this['getProp']() + this['getter'];
             ~~~~~~~~~~~~                                       [error no-restricted-property-access: Abstract property 'prop' in class 'Abstract' cannot be accessed during class initialization.]
-                                               ~~~~~~~~~~~~~~  [error no-restricted-property-access: Abstract property 'getter' in class 'Abstract' cannot be accessed during class initialization.]
     yetAnother = decorator(this['prop']);
                            ~~~~~~~~~~~~   [error no-restricted-property-access: Abstract property 'prop' in class 'Abstract' cannot be accessed during class initialization.]
     constructor(other: Abstract) {
@@ -163,9 +221,8 @@ abstract class Abstract {
         this['getProp']();
         other['prop'];
         this['getter'];
-        ~~~~~~~~~~~~~~  [error no-restricted-property-access: Abstract property 'getter' in class 'Abstract' cannot be accessed during class initialization.]
         () => this['prop'];
-        const {['prop']: prop, ['getter']: getter} = this; // TODO this could be an error
+        (this)['prop']; // should be an error, but TypeScript doesn't unwrap parens either
     }
     method() {
         this['prop'];
@@ -176,18 +233,18 @@ class DerivedAbstract extends Abstract {
     prop = 1;
     getter = 2;
     other = this['prop'] + this['getProp']() + super['getProp']() + super['prop'] + super['getter'] + this['getter'];
-                                               ~~~~~~~~~~~~~~~~                                                       [error no-restricted-property-access: Abstract method 'getProp' in class 'Abstract' cannot be accessed via the 'super' keyword.]
-                                                                    ~~~~~~~~~~~~~                                     [error no-restricted-property-access: Only public and protected methods of the base class are accessible via the 'super' keyword.]
-                                                                                    ~~~~~~~~~~~~~~~                   [error no-restricted-property-access: Only public and protected methods of the base class are accessible via the 'super' keyword.]
+                                               ~~~~~~~~~~~~~~~~                                                       [error no-restricted-property-access: Abstract member 'getProp' in class 'Abstract' cannot be accessed via the 'super' keyword.]
+                                                                    ~~~~~~~~~~~~~                                     [error no-restricted-property-access: Only public and protected methods and accessors of the base class are accessible via the 'super' keyword.]
+                                                                                    ~~~~~~~~~~~~~~~                   [error no-restricted-property-access: Abstract member 'getter' in class 'Abstract' cannot be accessed via the 'super' keyword.]
     constructor(other: Abstract) {
         super(other);
         other['prop'];
         this['prop'];
         this['getProp']();
         super['getProp']();
-        ~~~~~~~~~~~~~~~~    [error no-restricted-property-access: Abstract method 'getProp' in class 'Abstract' cannot be accessed via the 'super' keyword.]
+        ~~~~~~~~~~~~~~~~    [error no-restricted-property-access: Abstract member 'getProp' in class 'Abstract' cannot be accessed via the 'super' keyword.]
         super['prop'];
-        ~~~~~~~~~~~~~  [error no-restricted-property-access: Only public and protected methods of the base class are accessible via the 'super' keyword.]
+        ~~~~~~~~~~~~~  [error no-restricted-property-access: Only public and protected methods and accessors of the base class are accessible via the 'super' keyword.]
     }
 
     getProp() {
@@ -196,7 +253,7 @@ class DerivedAbstract extends Abstract {
     m() {
         return new class extends DerivedAbstract {
             other = super['getProp']() + super['prop'];
-                                         ~~~~~~~~~~~~~  [error no-restricted-property-access: Only public and protected methods of the base class are accessible via the 'super' keyword.]
+                                         ~~~~~~~~~~~~~  [error no-restricted-property-access: Only public and protected methods and accessors of the base class are accessible via the 'super' keyword.]
         }(this);
     }
 }
@@ -204,9 +261,8 @@ class DerivedAbstract extends Abstract {
 abstract class DerivedAbstractAbstract extends Abstract {
     other = this['prop'] + this['getProp']() + super['getProp']() + this['getter'] + super['getter'];
             ~~~~~~~~~~~~                                                                              [error no-restricted-property-access: Abstract property 'prop' in class 'DerivedAbstractAbstract' cannot be accessed during class initialization.]
-                                               ~~~~~~~~~~~~~~~~                                       [error no-restricted-property-access: Abstract method 'getProp' in class 'Abstract' cannot be accessed via the 'super' keyword.]
-                                                                    ~~~~~~~~~~~~~~                    [error no-restricted-property-access: Abstract property 'getter' in class 'DerivedAbstractAbstract' cannot be accessed during class initialization.]
-                                                                                     ~~~~~~~~~~~~~~~  [error no-restricted-property-access: Only public and protected methods of the base class are accessible via the 'super' keyword.]
+                                               ~~~~~~~~~~~~~~~~                                       [error no-restricted-property-access: Abstract member 'getProp' in class 'Abstract' cannot be accessed via the 'super' keyword.]
+                                                                                     ~~~~~~~~~~~~~~~  [error no-restricted-property-access: Abstract member 'getter' in class 'Abstract' cannot be accessed via the 'super' keyword.]
 
     constructor(other: Abstract) {
         super(other);
@@ -215,10 +271,8 @@ abstract class DerivedAbstractAbstract extends Abstract {
 
 abstract class EvenMoreDerivedAbstract extends DerivedAbstractAbstract {
     other = super['getProp']();
-            ~~~~~~~~~~~~~~~~    [error no-restricted-property-access: Abstract method 'getProp' in class 'Abstract' cannot be accessed via the 'super' keyword.]
+            ~~~~~~~~~~~~~~~~    [error no-restricted-property-access: Abstract member 'getProp' in class 'Abstract' cannot be accessed via the 'super' keyword.]
 }
-
-declare function decorator(...args: any[]): any;
 
 class A {
     protected prop = 1;
@@ -279,7 +333,7 @@ function Mixin<TBase extends Constructor>(Base: TBase) {
 class MixinSubclass extends Mixin(class {a() {return 1;}}) {
     method() {
         return super['method']();
-               ~~~~~~~~~~~~~~~    [error no-restricted-property-access: Abstract method 'method' in class 'C' cannot be accessed via the 'super' keyword.]
+               ~~~~~~~~~~~~~~~    [error no-restricted-property-access: Abstract member 'method' in class 'C' cannot be accessed via the 'super' keyword.]
     }
 }
 
@@ -303,5 +357,55 @@ declare const Base: new() => WithMethod & WithAbstractMethod;
 class IntersectionSubclass extends Base {
     doStuff() {
         return super['method']();
+    }
+}
+
+namespace testStatic {
+    class Base {
+        static prop = 1;
+        static method() {return 1;}
+        static get accessor() {return 1;}
+
+        v = 1;
+    }
+    namespace Base {
+        export var v = 1;
+    }
+
+    class Other {}
+
+    class Derived extends Base {
+        static fn() {
+            return super['prop'] + super['method']() + super['accessor'] + super['v'];
+        }
+
+        static nestedClass() {
+            @decorator(super['v'])
+            class C extends Other {
+                @decorator(super['v'])
+                static [super['v']](@decorator(super['v']) param: string) {}
+
+                @decorator(super['v'])
+                [super['v']](@decorator(super['v']) param: string) {}
+            }
+        }
+
+        nestedClass() {
+            @decorator(super['v'])
+                       ~~~~~~~~~~  [error no-restricted-property-access: Only public and protected methods and accessors of the base class are accessible via the 'super' keyword.]
+            class C extends Other {
+                @decorator(super['v'])
+                           ~~~~~~~~~~  [error no-restricted-property-access: Only public and protected methods and accessors of the base class are accessible via the 'super' keyword.]
+                static [super['v']](@decorator(super['v']) param: string) {}
+                        ~~~~~~~~~~                                           [error no-restricted-property-access: Only public and protected methods and accessors of the base class are accessible via the 'super' keyword.]
+                                               ~~~~~~~~~~                    [error no-restricted-property-access: Only public and protected methods and accessors of the base class are accessible via the 'super' keyword.]
+
+                @decorator(super['v'])
+                           ~~~~~~~~~~  [error no-restricted-property-access: Only public and protected methods and accessors of the base class are accessible via the 'super' keyword.]
+                [super['v']](@decorator(super['v']) param: string) {}
+                 ~~~~~~~~~~                                           [error no-restricted-property-access: Only public and protected methods and accessors of the base class are accessible via the 'super' keyword.]
+                                        ~~~~~~~~~~                    [error no-restricted-property-access: Only public and protected methods and accessors of the base class are accessible via the 'super' keyword.]
+            }
+        }
     }
 }

--- a/baselines/packages/mimir/test/no-restricted-property-access/default/test.ts.lint
+++ b/baselines/packages/mimir/test/no-restricted-property-access/default/test.ts.lint
@@ -409,3 +409,9 @@ namespace testStatic {
         }
     }
 }
+
+class MyClass extends Object {
+    toString() {
+        return super['toString']();
+    }
+}

--- a/packages/mimir/docs/no-restricted-property-access.md
+++ b/packages/mimir/docs/no-restricted-property-access.md
@@ -13,9 +13,8 @@ This rule implements the same checks as TypeScript but only for computed names w
 
 The following errors are detected:
 
-* accessing members with multiple declarations of conflicting visibility
 * accessing properties using `super`
-* accessing `abstract` methods using `super`
+* accessing `abstract` methods and accessors using `super`
 * accessing `abstract` properties during initialization of a class with no implementation for that property
 * accessing `private` and `protected` members outside of their visibility
 * accessing `protected` members on an instance of a super-class within a derived class
@@ -52,16 +51,6 @@ class D extends C {
     this['priv']; // accessing private member outside of the declaring class' body
     other['prot']; // accessing a protected member declared in a base class on an instance that is not instanceof the containing class
   }
-}
-
-class Public {
-  public prop = 1;
-}
-class Private {
-  private prop = 1;
-}
-function doStuff(instance: Public & Private) {
-  instance['prop']; // property has conflicting visibility modifiers
 }
 ```
 

--- a/packages/mimir/package.json
+++ b/packages/mimir/package.json
@@ -30,7 +30,7 @@
     "chalk": "^4.0.0",
     "debug": "^4.0.0",
     "tslib": "^2.0.0",
-    "tsutils": "^3.19.0"
+    "tsutils": "^3.19.1"
   },
   "peerDependencies": {
     "typescript": ">= 4.0.0 || >= 4.2.0-dev"

--- a/packages/mimir/test/no-restricted-property-access/test.ts
+++ b/packages/mimir/test/no-restricted-property-access/test.ts
@@ -1,3 +1,7 @@
+declare function decorator(...args: any[]): any;
+declare const BaseTypeWithoutDeclarations: new () => {};
+declare const BaseTypeWithoutSymbol: new () => object;
+
 class Private {
     private prop = 1;
     other = this['prop'];
@@ -60,8 +64,10 @@ function testProtected(this: Protected) {
         bar = new Protected()['prop'],
     }
     @decorator(new Protected()['prop'])
-    class Inner {
+    class Inner extends (new Protected()['prop'] ? Object : Object) {
         bar = new Protected()['prop'];
+        @decorator(new Protected()['prop'])
+        [new Protected()['prop']](@decorator(new Protected()['prop']) param: string) {}
     }
 }
 new Protected()['prop'];
@@ -94,9 +100,56 @@ function testDerivedProtected(this: DerivedProtected) {
     new Protected()['prop'];
 }
 
+interface I { something(): void }
+class DerivedProtectedWithImplements extends Protected implements I {
+    something() {
+        this['prop'];
+        new Protected()['fn'](null!);
+    }
+}
+
 class Unrelated {}
 function testUnrelated(this: Unrelated) {
     new Protected()['prop'];
+}
+
+class WithoutDeclarations extends BaseTypeWithoutDeclarations {
+    prop = new Protected()['prop'];
+}
+
+class WithoutSymbol extends BaseTypeWithoutSymbol {
+    prop = new Protected()['prop'];
+}
+
+function mixin<T extends new (...args: any[]) => object>(p: T) {
+    return class extends p {
+        constructor(...args: any[]) {
+            super(...args);
+            new Protected()['prop'];
+        }
+    }
+}
+
+function mixin2<T extends new (...args: any[]) => Protected>(p: T) {
+    return class extends p {
+        protected fromMixin = 1;
+        constructor(...args: any[]) {
+            super(...args);
+            this['prop'];
+            new Protected()['prop'];
+            Protected['fn'](null!);
+        }
+    };
+}
+
+const MixedIn = mixin2(Protected);
+new MixedIn()['fromMixin'];
+
+class ExtendsMixin extends MixedIn {
+    fn() {
+        this['fromMixin'];
+        new MixedIn()['fromMixin'];
+    }
 }
 
 new class {
@@ -135,7 +188,7 @@ abstract class Abstract {
         other['prop'];
         this['getter'];
         () => this['prop'];
-        const {['prop']: prop, ['getter']: getter} = this; // TODO this could be an error
+        (this)['prop']; // should be an error, but TypeScript doesn't unwrap parens either
     }
     method() {
         this['prop'];
@@ -176,8 +229,6 @@ abstract class DerivedAbstractAbstract extends Abstract {
 abstract class EvenMoreDerivedAbstract extends DerivedAbstractAbstract {
     other = super['getProp']();
 }
-
-declare function decorator(...args: any[]): any;
 
 class A {
     protected prop = 1;
@@ -256,5 +307,54 @@ declare const Base: new() => WithMethod & WithAbstractMethod;
 class IntersectionSubclass extends Base {
     doStuff() {
         return super['method']();
+    }
+}
+
+namespace testStatic {
+    class Base {
+        static prop = 1;
+        static method() {return 1;}
+        static get accessor() {return 1;}
+
+        v = 1;
+    }
+    namespace Base {
+        export var v = 1;
+    }
+
+    class Other {}
+
+    class Derived extends Base {
+        static fn() {
+            return super['prop'] + super['method']() + super['accessor'] + super['v'];
+        }
+
+        static nestedClass() {
+            @decorator(super['v'])
+            class C extends Other {
+                @decorator(super['v'])
+                static [super['v']](@decorator(super['v']) param: string) {}
+
+                @decorator(super['v'])
+                [super['v']](@decorator(super['v']) param: string) {}
+            }
+        }
+
+        nestedClass() {
+            @decorator(super['v'])
+            class C extends Other {
+                @decorator(super['v'])
+                static [super['v']](@decorator(super['v']) param: string) {}
+
+                @decorator(super['v'])
+                [super['v']](@decorator(super['v']) param: string) {}
+            }
+        }
+    }
+}
+
+class MyClass extends Object {
+    toString() {
+        return super['toString']();
     }
 }

--- a/packages/mimir/test/no-restricted-property-access/tsconfig.json
+++ b/packages/mimir/test/no-restricted-property-access/tsconfig.json
@@ -3,6 +3,7 @@
     "strict": true,
     "target": "esnext",
     "allowJs": true,
-    "checkJs": true
+    "checkJs": true,
+    "experimentalDecorators": true
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3785,10 +3785,10 @@ tsutils@^2.29.0:
   dependencies:
     tslib "^1.8.1"
 
-tsutils@^3.18.0, tsutils@^3.19.0, tsutils@^3.5.0, tsutils@^3.5.1:
-  version "3.19.0"
-  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-3.19.0.tgz#9387cb5fcb71579aa0909c509604f8a7fbe1cff1"
-  integrity sha512-A7BaLUPvcQ1cxVu72YfD+UMI3SQPTDv/w4ol6TOwLyI0hwfG9EC+cYlhdflJTmtYTgZ3KqdPSe/otxU4K3kArg==
+tsutils@^3.18.0, tsutils@^3.19.1, tsutils@^3.5.0, tsutils@^3.5.1:
+  version "3.19.1"
+  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-3.19.1.tgz#d8566e0c51c82f32f9c25a4d367cd62409a547a9"
+  integrity sha512-GEdoBf5XI324lu7ycad7s6laADfnAqCw6wLGI+knxvw9vsIYBaJfYdmeCEG3FMMUiSm3OGgNb+m6utsWf5h9Vw==
   dependencies:
     tslib "^1.8.1"
 


### PR DESCRIPTION
#### Checklist

- [x] Fixes: #736
- [x] Fixes: #737
- [x] Added or updated tests / baselines
- [x] Documentation update

#### Overview of change 
* allow accessing all members via static 'super'
* allow accessing accessors via 'super'
* allow accessing abstract accessors via 'this' in constructor
* treat MethodSignature like MethodDeclaration
* fix lookup of 'this' container for decorators and computed property names
