### PR TITLE
Optimize usage of WrappedAst

### DIFF
--- a/packages/mimir/src/rules/await-async-result.ts
+++ b/packages/mimir/src/rules/await-async-result.ts
@@ -9,7 +9,7 @@ export class Rule extends TypedRule {
         const re = /\basync\b/g;
         let wrappedAst: WrappedAst | undefined;
         for (let match = re.exec(this.sourceFile.text); match !== null; match = re.exec(this.sourceFile.text)) {
-            const {node} = getWrappedNodeAtPosition(wrappedAst || (wrappedAst = this.context.getWrappedAst()), match.index)!;
+            const {node} = getWrappedNodeAtPosition(wrappedAst ??= this.context.getWrappedAst(), match.index)!;
             if (node.kind !== ts.SyntaxKind.AsyncKeyword || node.end !== re.lastIndex)
                 continue;
             const parent = node.parent!;

--- a/packages/mimir/src/rules/await-only-promise.ts
+++ b/packages/mimir/src/rules/await-only-promise.ts
@@ -17,7 +17,7 @@ export class Rule extends TypedRule {
         const re = /\bawait\b/g;
         let wrappedAst: WrappedAst | undefined;
         for (let match = re.exec(this.sourceFile.text); match !== null; match = re.exec(this.sourceFile.text)) {
-            const {node} = getWrappedNodeAtPosition(wrappedAst || (wrappedAst = this.context.getWrappedAst()), match.index)!;
+            const {node} = getWrappedNodeAtPosition(wrappedAst ??= this.context.getWrappedAst(), match.index)!;
             if (isAwaitExpression(node)) {
                 if (
                     node.expression.pos !== re.lastIndex ||

--- a/packages/mimir/src/rules/delete-only-optional-property.ts
+++ b/packages/mimir/src/rules/delete-only-optional-property.ts
@@ -15,7 +15,7 @@ export class Rule extends TypedRule {
         const re = /\bdelete\b/g;
         let wrappedAst: WrappedAst | undefined;
         for (let match = re.exec(this.sourceFile.text); match !== null; match = re.exec(this.sourceFile.text)) {
-            const {node} = getWrappedNodeAtPosition(wrappedAst || (wrappedAst = this.context.getWrappedAst()), match.index)!;
+            const {node} = getWrappedNodeAtPosition(wrappedAst ??= this.context.getWrappedAst(), match.index)!;
             if (!isDeleteExpression(node) || node.expression.pos !== re.lastIndex)
                 continue;
             const {expression} = node;

--- a/packages/mimir/src/rules/new-parens.ts
+++ b/packages/mimir/src/rules/new-parens.ts
@@ -10,7 +10,7 @@ export class Rule extends AbstractRule {
         const re = /\bnew\b/g;
 
         for (let match = re.exec(text); match !== null; match = re.exec(text)) {
-            const {node} = getWrappedNodeAtPosition(wrappedAst || (wrappedAst = this.context.getWrappedAst()), match.index)!;
+            const {node} = getWrappedNodeAtPosition(wrappedAst ??= this.context.getWrappedAst(), match.index)!;
             if (node.kind === ts.SyntaxKind.NewExpression &&
                 text[node.end - 1] !== ')' &&
                 re.lastIndex === (<ts.NewExpression>node).expression.pos)

--- a/packages/mimir/src/rules/no-debugger.ts
+++ b/packages/mimir/src/rules/no-debugger.ts
@@ -9,7 +9,7 @@ export class Rule extends AbstractRule {
         let wrappedAst: WrappedAst | undefined;
         const text = this.sourceFile.text;
         for (let match = re.exec(text); match !== null; match = re.exec(text)) {
-            const {node} = getWrappedNodeAtPosition(wrappedAst || (wrappedAst = this.context.getWrappedAst()), match.index)!;
+            const {node} = getWrappedNodeAtPosition(wrappedAst ??= this.context.getWrappedAst(), match.index)!;
             if (node.kind === ts.SyntaxKind.DebuggerStatement) {
                 const start = node.getStart(this.sourceFile);
                 if (start === match.index)

--- a/packages/mimir/src/rules/no-nan-compare.ts
+++ b/packages/mimir/src/rules/no-nan-compare.ts
@@ -8,7 +8,7 @@ export class Rule extends AbstractRule {
         const re = /\bNaN\b/g;
         let wrappedAst: WrappedAst | undefined;
         for (let match = re.exec(this.sourceFile.text); match !== null; match = re.exec(this.sourceFile.text)) {
-            const {node} = getWrappedNodeAtPosition(wrappedAst || (wrappedAst = this.context.getWrappedAst()), match.index)!;
+            const {node} = getWrappedNodeAtPosition(wrappedAst ??= this.context.getWrappedAst(), match.index)!;
             if (!isIdentifier(node) || node.text !== 'NaN' || node.end !== match.index + 3)
                 continue;
             let parent = node.parent!;

--- a/packages/mimir/src/rules/no-octal-escape.ts
+++ b/packages/mimir/src/rules/no-octal-escape.ts
@@ -10,7 +10,7 @@ export class Rule extends AbstractRule {
         for (let match = re.exec(this.sourceFile.text); match !== null; match = re.exec(this.sourceFile.text)) {
             if (match[1].length & 1) // only check if backslash is not escaped
                 continue;
-            const {node} = getWrappedNodeAtPosition(wrappedAst || (wrappedAst = this.context.getWrappedAst()), match.index)!;
+            const {node} = getWrappedNodeAtPosition(wrappedAst ??= this.context.getWrappedAst(), match.index)!;
             switch (node.kind) {
                 case ts.SyntaxKind.StringLiteral:
                 case ts.SyntaxKind.NoSubstitutionTemplateLiteral:

--- a/packages/mimir/src/rules/no-return-await.ts
+++ b/packages/mimir/src/rules/no-return-await.ts
@@ -11,7 +11,7 @@ export class Rule extends AbstractRule {
         const re = /(?:^|\|\||&&|return|=>|\*\/|[,(?:])\s*await\b/mg;
         let wrappedAst: WrappedAst | undefined;
         for (let match = re.exec(this.sourceFile.text); match !== null; match = re.exec(this.sourceFile.text)) {
-            const {node} = getWrappedNodeAtPosition(wrappedAst || (wrappedAst = this.context.getWrappedAst()), re.lastIndex - 1)!;
+            const {node} = getWrappedNodeAtPosition(wrappedAst ??= this.context.getWrappedAst(), re.lastIndex - 1)!;
             if (isAwaitExpression(node) && re.lastIndex === node.expression.pos && isUnnecessaryAwait(node)) {
                 const keywordStart = node.expression.pos - 'await'.length;
                 const replacements = [Replacement.delete(keywordStart, node.expression.getStart(this.sourceFile))];

--- a/packages/mimir/src/rules/no-unsafe-finally.ts
+++ b/packages/mimir/src/rules/no-unsafe-finally.ts
@@ -7,7 +7,7 @@ export class Rule extends AbstractRule {
         const re = /\bfinally\s*[/{]/g;
         let wrappedAst: WrappedAst | undefined;
         for (let match = re.exec(this.sourceFile.text); match !== null; match = re.exec(this.sourceFile.text)) {
-            const {node} = getWrappedNodeAtPosition(wrappedAst || (wrappedAst = this.context.getWrappedAst()), match.index)!;
+            const {node} = getWrappedNodeAtPosition(wrappedAst ??= this.context.getWrappedAst(), match.index)!;
             if (isTryStatement(node) && node.finallyBlock !== undefined && node.finallyBlock.pos === match.index + 'finally'.length)
                 for (const statement of getControlFlowEnd(node.finallyBlock).statements)
                     this.addFindingAtNode(

--- a/packages/mimir/src/rules/no-useless-initializer.ts
+++ b/packages/mimir/src/rules/no-useless-initializer.ts
@@ -90,7 +90,7 @@ export class Rule extends AbstractRule {
         function maybeUndefined({symbolName}: PropertyName) {
             return symbolMaybeUndefined(
                 checker,
-                getPropertyOfType(type || (type = checker.getApparentType(checker.getTypeOfAssignmentPattern(node))), symbolName),
+                getPropertyOfType(type ??= checker.getApparentType(checker.getTypeOfAssignmentPattern(node)), symbolName),
                 node,
             );
         }
@@ -140,7 +140,7 @@ export class Rule extends AbstractRule {
         function maybeUndefined({symbolName}: PropertyName) {
             return symbolMaybeUndefined(
                 checker,
-                getPropertyOfType(type || (type = checker.getApparentType(checker.getTypeAtLocation(node)!)), symbolName),
+                getPropertyOfType(type ??= checker.getApparentType(checker.getTypeAtLocation(node)!), symbolName),
                 node,
             );
         }

--- a/packages/mimir/src/rules/no-useless-jump-label.ts
+++ b/packages/mimir/src/rules/no-useless-jump-label.ts
@@ -16,7 +16,7 @@ export class Rule extends AbstractRule {
         const re = /\b(break|continue)(?:\s|\/*)/gm;
         let wrappedAst: WrappedAst | undefined;
         for (let match = re.exec(text); match !== null; match = re.exec(text)) {
-            const {node} = getWrappedNodeAtPosition(wrappedAst || (wrappedAst = this.context.getWrappedAst()), match.index)!;
+            const {node} = getWrappedNodeAtPosition(wrappedAst ??= this.context.getWrappedAst(), match.index)!;
             if (
                 isBreakOrContinueStatement(node) &&
                 node.label !== undefined &&

--- a/packages/mimir/src/rules/no-useless-spread.ts
+++ b/packages/mimir/src/rules/no-useless-spread.ts
@@ -19,10 +19,7 @@ export class Rule extends AbstractRule {
         const re = /\.{3}\s*[/[{]/g;
         let wrappedAst: WrappedAst | undefined;
         for (let match = re.exec(this.sourceFile.text); match !== null; match = re.exec(this.sourceFile.text)) {
-            const { node } = getWrappedNodeAtPosition(
-                wrappedAst || (wrappedAst = this.context.getWrappedAst()),
-                match.index,
-            )!;
+            const { node } = getWrappedNodeAtPosition(wrappedAst ??= this.context.getWrappedAst(), match.index)!;
             switch (node.kind) {
                 case ts.SyntaxKind.SpreadElement:
                     if ((<ts.SpreadElement>node).expression.pos - 3 === match.index)

--- a/packages/mimir/src/rules/no-useless-strict.ts
+++ b/packages/mimir/src/rules/no-useless-strict.ts
@@ -24,7 +24,7 @@ export class Rule extends AbstractRule {
         const re = /(['"])use strict\1/g;
         let wrappedAst: WrappedAst | undefined;
         for (let match = re.exec(this.sourceFile.text); match !== null; match = re.exec(this.sourceFile.text)) {
-            const {node} = getWrappedNodeAtPosition(wrappedAst || (wrappedAst = this.context.getWrappedAst()), match.index)!;
+            const {node} = getWrappedNodeAtPosition(wrappedAst ??= this.context.getWrappedAst(), match.index)!;
             if (
                 node.end === re.lastIndex &&
                 isStringLiteral(node) &&

--- a/packages/mimir/src/rules/prefer-number-methods.ts
+++ b/packages/mimir/src/rules/prefer-number-methods.ts
@@ -9,7 +9,7 @@ export class Rule extends TypedRule {
         const re = /\b(?:isNaN|isFinite)\s*[/(]/g;
         let wrappedAst: WrappedAst | undefined;
         for (let match = re.exec(this.sourceFile.text); match !== null; match = re.exec(this.sourceFile.text)) {
-            const {node} = getWrappedNodeAtPosition(wrappedAst || (wrappedAst = this.context.getWrappedAst()), match.index)!;
+            const {node} = getWrappedNodeAtPosition(wrappedAst ??= this.context.getWrappedAst(), match.index)!;
             if (!isIdentifier(node) || node.text !== 'isNaN' && node.text !== 'isFinite' || node.end - node.text.length !== match.index)
                 continue;
             const parent = node.parent!;

--- a/packages/mimir/src/rules/prefer-object-spread.ts
+++ b/packages/mimir/src/rules/prefer-object-spread.ts
@@ -18,7 +18,7 @@ export class Rule extends TypedRule {
         const re = /(?:[.\n]|\*\/)\s*assign\b/g;
         let wrappedAst: WrappedAst | undefined;
         for (let match = re.exec(this.sourceFile.text); match !== null; match = re.exec(this.sourceFile.text)) {
-            const {node} = getWrappedNodeAtPosition(wrappedAst || (wrappedAst = this.context.getWrappedAst()), re.lastIndex - 1)!;
+            const {node} = getWrappedNodeAtPosition(wrappedAst ??= this.context.getWrappedAst(), re.lastIndex - 1)!;
             if (node.kind !== ts.SyntaxKind.Identifier || node.end !== re.lastIndex)
                 continue;
             const parent = node.parent!;

--- a/packages/mimir/src/rules/type-assertion.ts
+++ b/packages/mimir/src/rules/type-assertion.ts
@@ -26,7 +26,7 @@ function enforceClassicTypeAssertion(context: RuleContext) {
     const re = /\bas\b/g;
     let wrappedAst: WrappedAst | undefined;
     for (let match = re.exec(context.sourceFile.text); match !== null; match = re.exec(context.sourceFile.text)) {
-        const {node} = getWrappedNodeAtPosition(wrappedAst || (wrappedAst = context.getWrappedAst()), match.index)!;
+        const {node} = getWrappedNodeAtPosition(wrappedAst ??= context.getWrappedAst(), match.index)!;
         if (!isAsExpression(node) || node.type.pos !== re.lastIndex)
             continue;
         const parent = node.parent!;

--- a/packages/mimir/src/utils.ts
+++ b/packages/mimir/src/utils.ts
@@ -18,7 +18,7 @@ export function* switchStatements(context: RuleContext) {
     const re = /\bswitch\s*[(/]/g;
     let wrappedAst: WrappedAst | undefined;
     for (let match = re.exec(text); match !== null; match = re.exec(text)) {
-        const {node} = getWrappedNodeAtPosition(wrappedAst || (wrappedAst = context.getWrappedAst()), match.index)!;
+        const {node} = getWrappedNodeAtPosition(wrappedAst ??= context.getWrappedAst(), match.index)!;
         if (node.kind === ts.SyntaxKind.SwitchStatement && node.getStart(context.sourceFile) === match.index)
             yield <ts.SwitchStatement>node;
     }
@@ -29,7 +29,7 @@ export function* tryStatements(context: RuleContext) {
     const re = /\btry\s*[{/]/g;
     let wrappedAst: WrappedAst | undefined;
     for (let match = re.exec(text); match !== null; match = re.exec(text)) {
-        const {node} = getWrappedNodeAtPosition(wrappedAst || (wrappedAst = context.getWrappedAst()), match.index)!;
+        const {node} = getWrappedNodeAtPosition(wrappedAst ??= context.getWrappedAst(), match.index)!;
         if (node.kind === ts.SyntaxKind.TryStatement && (<ts.TryStatement>node).tryBlock.pos - 'try'.length === match.index)
             yield <ts.TryStatement>node;
     }

--- a/packages/wotan/src/linter.ts
+++ b/packages/wotan/src/linter.ts
@@ -54,7 +54,7 @@ class CachedProgramFactory implements ProgramFactory {
     constructor(private factory: ProgramFactory) {}
 
     public getCompilerOptions() {
-        return this.options || (this.options = this.factory.getCompilerOptions());
+        return this.options ??= this.factory.getCompilerOptions();
     }
 
     public getProgram() {
@@ -310,10 +310,10 @@ export class Linter {
         return result;
 
         function getFlatAst() {
-            return (convertedAst || (convertedAst = convertAst(sourceFile))).flat;
+            return (convertedAst ??= convertAst(sourceFile)).flat;
         }
         function getWrappedAst() {
-            return (convertedAst || (convertedAst = convertAst(sourceFile))).wrapped;
+            return (convertedAst ??= convertAst(sourceFile)).wrapped;
         }
     }
 }

--- a/packages/wotan/src/services/default/line-switches.ts
+++ b/packages/wotan/src/services/default/line-switches.ts
@@ -59,7 +59,7 @@ export class LineSwitchFilterFactory implements FindingFilterFactory {
         const raw = this.parser.parse({
             sourceFile,
             getCommentAtPosition(pos) {
-                const wrap = getWrappedNodeAtPosition(wrappedAst || (wrappedAst = context.getWrappedAst()), pos);
+                const wrap = getWrappedNodeAtPosition(wrappedAst ??= context.getWrappedAst(), pos);
                 if (wrap === undefined)
                     return;
                 return getCommentAtPosition(sourceFile, pos, wrap.node);


### PR DESCRIPTION
Avoid excessive stack depth in `async-function-assignability` and `generator-require-yield` on very deep AST structures.

This should also increase performance by avoiding recursion where possible.
