### PR TITLE
ls plugin: add support for code fixes

### DIFF
--- a/baselines/packages/wotan/api/language-service/index.d.ts
+++ b/baselines/packages/wotan/api/language-service/index.d.ts
@@ -1,9 +1,6 @@
 import * as ts from 'typescript';
-export declare type PartialLanguageServiceInterceptor = {
-    [K in keyof ts.LanguageService]?: ts.LanguageService[K] extends (...args: infer Parameters) => infer Return ? (prev: Return, ...args: Parameters) => Return : ts.LanguageService[K];
-};
-export declare const version = "1";
-export declare class LanguageServiceInterceptor implements PartialLanguageServiceInterceptor {
+export declare const version = "2";
+export declare class LanguageServiceInterceptor implements Partial<ts.LanguageService> {
     protected config: Record<string, unknown>;
     protected project: import('typescript/lib/tsserverlibrary').server.Project;
     protected serverHost: import('typescript/lib/tsserverlibrary').server.ServerHost;
@@ -13,8 +10,10 @@ export declare class LanguageServiceInterceptor implements PartialLanguageServic
     getExternalFiles?: () => string[];
     constructor(config: Record<string, unknown>, project: import('typescript/lib/tsserverlibrary').server.Project, serverHost: import('typescript/lib/tsserverlibrary').server.ServerHost, languageService: ts.LanguageService, require: (id: string) => {}, log: (message: string) => void);
     updateConfig(config: Record<string, unknown>): void;
-    getSemanticDiagnostics(diagnostics: ts.Diagnostic[], fileName: string): ts.Diagnostic[];
-    getSuggestionDiagnostics(diagnostics: ts.DiagnosticWithLocation[], fileName: string): ts.DiagnosticWithLocation[];
+    getSemanticDiagnostics(fileName: string): ts.Diagnostic[];
+    getSuggestionDiagnostics(fileName: string): ts.DiagnosticWithLocation[];
+    getCodeFixesAtPosition(fileName: string, start: number, end: number, errorCodes: readonly number[], formatOptions: ts.FormatCodeSettings, preferences: ts.UserPreferences): readonly ts.CodeFixAction[];
+    getCombinedCodeFix(scope: ts.CombinedCodeFixScope, fixId: {}, formatOptions: ts.FormatCodeSettings, preferences: ts.UserPreferences): ts.CombinedCodeActions;
     getSupportedCodeFixes(fixes: string[]): string[];
     cleanupSemanticCache(): void;
     dispose(): void;

--- a/packages/mithotyn/README.md
+++ b/packages/mithotyn/README.md
@@ -54,7 +54,7 @@ The following options are used if present in that file. Note that all paths and 
 
 To customize your in-editor linting experience you can use the following configuration options:
 
-* `displayErrorsAsWarnings: boolean`: Report findings with severity `error` as warning to make them distinguishable from real type errors (e.g. green instead of red squiggles in VS Code)
+* `displayErrorsAsWarnings: boolean`: Report findings with severity `error` as warning to make them distinguishable from real type errors (e.g. yellow instead of red squiggles in VS Code)
 
 Example:
 
@@ -95,7 +95,6 @@ There are some limitations of the current implementation.
 The following limitations will likely be fixed in future releases.
 
 * Currently only works with TypeScript installed in your workspace, see [Usage in VS Code](#usage-in-vs-code)
-* doesn't provide code fixes for findings
 * doesn't validate `.wotanrc.yaml` and `.fimbullinter.yaml` files
 * doesn't refresh lint findings if configuration changes; you need to reopen or change the file
 


### PR DESCRIPTION
Adds code actions to the language service plugin.

Requires a new release of the VSCode plugin with the new version of `@fimbul/mithotyn` after the next release.