### PR TITLE
Fix wotan with typescript 4.4+

### DIFF
--- a/packages/wotan/src/project-host.ts
+++ b/packages/wotan/src/project-host.ts
@@ -70,6 +70,7 @@ export class ProjectHost implements ts.CompilerHost {
             depth,
             (dir) => resolveCachedResult(this.directoryEntries, dir, this.processDirectory),
             (f) => this.safeRealpath(f),
+            (path) => this.directoryExists(path),
         );
     }
     /**
@@ -320,6 +321,7 @@ declare module 'typescript' {
         depth: number | undefined,
         getFileSystemEntries: (path: string) => ts.FileSystemEntries,
         realpath: (path: string) => string,
+        directoryExists: (path: string) => boolean,
     ): string[];
 
     interface FileSystemEntries {

--- a/packages/wotan/src/project-host.ts
+++ b/packages/wotan/src/project-host.ts
@@ -70,7 +70,7 @@ export class ProjectHost implements ts.CompilerHost {
             depth,
             (dir) => resolveCachedResult(this.directoryEntries, dir, this.processDirectory),
             (f) => this.safeRealpath(f),
-            (path) => this.directoryExists(path),
+            (dir) => this.directoryExists(dir),
         );
     }
     /**

--- a/packages/wotan/test/dependency-resolver.spec.ts
+++ b/packages/wotan/test/dependency-resolver.spec.ts
@@ -58,9 +58,9 @@ function setup(fileContents: DirectoryJSON, useSourceOfProjectReferenceRedirect?
                 return result;
             },
             identity,
-            (path) => {
+            (dir) => {
               try {
-                  vol.readdirSync(path);
+                  vol.readdirSync(dir);
                   return true;
               } catch {
                   return false;

--- a/packages/wotan/test/dependency-resolver.spec.ts
+++ b/packages/wotan/test/dependency-resolver.spec.ts
@@ -58,6 +58,14 @@ function setup(fileContents: DirectoryJSON, useSourceOfProjectReferenceRedirect?
                 return result;
             },
             identity,
+            (path) => {
+              try {
+                  vol.readdirSync(path);
+                  return true;
+              } catch {
+                  return false;
+              }
+          },
         );
     }
 

--- a/packages/wotan/test/program-state.spec.ts
+++ b/packages/wotan/test/program-state.spec.ts
@@ -70,9 +70,9 @@ function setup(
                 return result;
             },
             identity,
-            (path) => {
+            (dir) => {
               try {
-                  vol.readdirSync(path);
+                  vol.readdirSync(dir);
                   return true;
               } catch {
                   return false;

--- a/packages/wotan/test/program-state.spec.ts
+++ b/packages/wotan/test/program-state.spec.ts
@@ -70,6 +70,14 @@ function setup(
                 return result;
             },
             identity,
+            (path) => {
+              try {
+                  vol.readdirSync(path);
+                  return true;
+              } catch {
+                  return false;
+              }
+          },
         );
     }
 


### PR DESCRIPTION
#### Checklist

- [X] Fixes: `TypeError: directoryExists is not a function`
- [X] Added or updated tests / baselines

#### Overview of change 
Typescript 4.4+ added a new required parameter called directoryExists to their matchFiles utility function. See [here](https://github.com/microsoft/TypeScript/pull/44710/files#diff-1516c8349f7a625a2e4a2aa60f6bbe84e4b1a499128e8705d3087d893e01d367)

When using wotan in a project using typescript >= 4.4 the following exception would be thrown
```
> wotan -c tslint.json -p tsconfig.json "private/**/*.ts"

TypeError: directoryExists is not a function
    at Object.matchFiles (/runner/node_modules/typescript/lib/typescript.js:20102:17)
    at ProjectHost.readDirectory (/runner/node_modules/@fimbul/wotan/src/project-host.js:42:19)
    at Object.readDirectory (/runner/node_modules/@fimbul/wotan/src/project-host.js:28:85)
    at getFileNamesFromConfigSpecs (/runner/node_modules/typescript/lib/typescript.js:40747:40)
    at getFileNames (/runner/node_modules/typescript/lib/typescript.js:40250:29)
    at parseJsonConfigFileContentWorker (/runner/node_modules/typescript/lib/typescript.js:40183:24)
    at Object.parseJsonSourceFileConfigFileContent (/runner/node_modules/typescript/lib/typescript.js:40135:16)
    at ProjectHost.parseConfigFile (/runner/node_modules/@fimbul/wotan/src/project-host.js:225:19)
    at Object.resolveCachedResult (/runner/node_modules/@fimbul/wotan/src/utils.js:25:18)
    at ProjectHost.getParsedCommandLine (/runner/node_modules/@fimbul/wotan/src/project-host.js:217:24)
```